### PR TITLE
Adding contract factory

### DIFF
--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/token/common/ERC2981.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol";
 
-import "erc721a/contracts/ERC721A.sol";
+import "erc721a-upgradeable/contracts/ERC721AUpgradeable.sol";
 
 import "./BatchReveal.sol";
 import "./LaunchpegErrors.sol";
@@ -15,14 +15,14 @@ import "./interfaces/IBaseLaunchpeg.sol";
 /// @author Trader Joe
 /// @notice Implements the functionalities shared between Launchpeg and FlatLaunchpeg contracts.
 abstract contract BaseLaunchpeg is
-    ERC721A,
-    Ownable,
-    ReentrancyGuard,
     IBaseLaunchpeg,
+    ERC721AUpgradeable,
     BatchReveal,
-    ERC2981
+    OwnableUpgradeable,
+    ReentrancyGuardUpgradeable,
+    ERC2981Upgradeable
 {
-    using Strings for uint256;
+    using StringsUpgradeable for uint256;
 
     /// @notice The collection size (e.g 10000)
     uint256 public override collectionSize;
@@ -62,11 +62,6 @@ abstract contract BaseLaunchpeg is
 
     /// @dev Tracks the amount of NFTs minted by `projectOwner`
     uint256 internal _amountMintedByDevs;
-
-    /// @dev Made to override ERC721's name()
-    string private _launchegName;
-    /// @dev Made to override ERC721's symbol()
-    string private _launchegSymbol;
 
     /// @dev Emitted on initializeJoeFee()
     /// @param feePercent The fees collected by Joepegs on the sale benefits
@@ -136,7 +131,9 @@ abstract contract BaseLaunchpeg is
         uint256 _collectionSize,
         uint256 _amountForDevs,
         uint256 _batchRevealSize
-    ) internal {
+    ) internal onlyInitializing {
+        __Ownable_init();
+        __ERC721A_init(_name, _symbol);
         initializeBatchReveal(_batchRevealSize, _collectionSize);
 
         if (_projectOwner == address(0)) {
@@ -146,9 +143,6 @@ abstract contract BaseLaunchpeg is
         if (_amountForDevs > _collectionSize) {
             revert Launchpeg__LargerCollectionSizeNeeded();
         }
-
-        _launchegName = _name;
-        _launchegSymbol = _symbol;
 
         projectOwner = _projectOwner;
         // Default royalty is 5%
@@ -319,35 +313,13 @@ abstract contract BaseLaunchpeg is
         return _ownershipOf(_tokenId);
     }
 
-    /// @notice Returns the collection name
-    /// @return Name Collection name
-    function name()
-        public
-        view
-        override(ERC721A, IERC721Metadata)
-        returns (string memory)
-    {
-        return _launchegName;
-    }
-
-    /// @notice Returns the collection symbol
-    /// @return Symbol Collection symbol
-    function symbol()
-        public
-        view
-        override(ERC721A, IERC721Metadata)
-        returns (string memory)
-    {
-        return _launchegSymbol;
-    }
-
     /// @notice Returns the Uniform Resource Identifier (URI) for `tokenId` token.
     /// @param _id Token id
     /// @return URI Token URI
     function tokenURI(uint256 _id)
         public
         view
-        override(ERC721A, IERC721Metadata)
+        override(ERC721AUpgradeable, IERC721MetadataUpgradeable)
         returns (string memory)
     {
         if (_id >= lastTokenRevealed) {
@@ -386,7 +358,7 @@ abstract contract BaseLaunchpeg is
         public
         view
         virtual
-        override(ERC721A, ERC2981, IERC165)
+        override(ERC721AUpgradeable, ERC2981Upgradeable, IERC165Upgradeable)
         returns (bool)
     {
         return super.supportsInterface(_interfaceId);

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -25,17 +25,17 @@ abstract contract BaseLaunchpeg is
     using Strings for uint256;
 
     /// @notice The collection size (e.g 10000)
-    uint256 public immutable override collectionSize;
+    uint256 public override collectionSize;
 
     /// @notice Amount of NFTs reserved for `projectOwner` (e.g 200)
     /// @dev It can be minted any time via `devMint`
-    uint256 public immutable override amountForDevs;
+    uint256 public override amountForDevs;
 
     /// @notice Max amount of NFTs that can be minted at once
-    uint256 public immutable override maxBatchSize;
+    uint256 public override maxBatchSize;
 
     /// @notice Max amount of NFTs an address can mint
-    uint256 public immutable override maxPerAddressDuringMint;
+    uint256 public override maxPerAddressDuringMint;
 
     /// @notice The fees collected by Joepegs on the sale benefits
     /// @dev In basis points e.g 100 for 1%
@@ -62,6 +62,11 @@ abstract contract BaseLaunchpeg is
 
     /// @dev Tracks the amount of NFTs minted by `projectOwner`
     uint256 internal _amountMintedByDevs;
+
+    /// @dev Made to override ERC721's name()
+    string private _launchegName;
+    /// @dev Made to override ERC721's symbol()
+    string private _launchegSymbol;
 
     /// @dev Emitted on initializeJoeFee()
     /// @param feePercent The fees collected by Joepegs on the sale benefits
@@ -113,7 +118,7 @@ abstract contract BaseLaunchpeg is
         _;
     }
 
-    /// @dev BaseLaunchpeg constructor
+    /// @dev BaseLaunchpeg initialization
     /// @param _name ERC721 name
     /// @param _symbol ERC721 symbol
     /// @param _projectOwner The project owner
@@ -122,7 +127,7 @@ abstract contract BaseLaunchpeg is
     /// @param _collectionSize The collection size (e.g 10000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
     /// @param _batchRevealSize Size of the batch reveal
-    constructor(
+    function initializeBaseLaunchpeg(
         string memory _name,
         string memory _symbol,
         address _projectOwner,
@@ -131,7 +136,9 @@ abstract contract BaseLaunchpeg is
         uint256 _collectionSize,
         uint256 _amountForDevs,
         uint256 _batchRevealSize
-    ) ERC721A(_name, _symbol) BatchReveal(_batchRevealSize, _collectionSize) {
+    ) internal {
+        initializeBatchReveal(_batchRevealSize, _collectionSize);
+
         if (_projectOwner == address(0)) {
             revert Launchpeg__InvalidProjectOwner();
         }
@@ -139,6 +146,9 @@ abstract contract BaseLaunchpeg is
         if (_amountForDevs > _collectionSize) {
             revert Launchpeg__LargerCollectionSizeNeeded();
         }
+
+        _launchegName = _name;
+        _launchegSymbol = _symbol;
 
         projectOwner = _projectOwner;
         // Default royalty is 5%
@@ -307,6 +317,28 @@ abstract contract BaseLaunchpeg is
         returns (TokenOwnership memory)
     {
         return _ownershipOf(_tokenId);
+    }
+
+    /// @notice Returns the collection name
+    /// @return Name Collection name
+    function name()
+        public
+        view
+        override(ERC721A, IERC721Metadata)
+        returns (string memory)
+    {
+        return _launchegName;
+    }
+
+    /// @notice Returns the collection symbol
+    /// @return Symbol Collection symbol
+    function symbol()
+        public
+        view
+        override(ERC721A, IERC721Metadata)
+        returns (string memory)
+    {
+        return _launchegSymbol;
     }
 
     /// @notice Returns the Uniform Resource Identifier (URI) for `tokenId` token.

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -1,6 +1,8 @@
 //SPDX-License-Identifier: CC0
 pragma solidity ^0.8.4;
 
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
 import "./interfaces/IBatchReveal.sol";
 import "./LaunchpegErrors.sol";
 
@@ -9,7 +11,7 @@ import "./LaunchpegErrors.sol";
 
 /// @title BatchReveal
 /// @notice Implements a gas efficient way of revealing NFT URIs gradually
-abstract contract BatchReveal is IBatchReveal {
+abstract contract BatchReveal is IBatchReveal, Initializable {
     /// @dev Initialized on parent contract creation
     uint256 private collectionSize;
     int128 private intCollectionSize;
@@ -51,7 +53,7 @@ abstract contract BatchReveal is IBatchReveal {
     function initializeBatchReveal(
         uint256 _revealBatchSize,
         uint256 _collectionSize
-    ) internal {
+    ) internal onlyInitializing {
         if (_collectionSize % _revealBatchSize != 0 || _revealBatchSize == 0) {
             revert Launchpeg__InvalidBatchRevealSize();
         }

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -11,12 +11,12 @@ import "./LaunchpegErrors.sol";
 /// @notice Implements a gas efficient way of revealing NFT URIs gradually
 abstract contract BatchReveal is IBatchReveal {
     /// @dev Initialized on parent contract creation
-    uint256 private immutable collectionSize;
-    int128 private immutable intCollectionSize;
+    uint256 private collectionSize;
+    int128 private intCollectionSize;
 
     /// @notice Size of the batch reveal
     /// @dev Must divide collectionSize
-    uint256 public immutable override revealBatchSize;
+    uint256 public override revealBatchSize;
 
     /// @notice Randomized seeds used to shuffle TokenURIs
     mapping(uint256 => uint256) public override batchToSeed;
@@ -25,7 +25,7 @@ abstract contract BatchReveal is IBatchReveal {
     uint256 public override lastTokenRevealed = 0;
 
     /// @dev Size of the array that will store already taken URIs numbers
-    uint256 private immutable _rangeLength;
+    uint256 private _rangeLength;
 
     /// @notice Timestamp for the start of the reveal process
     /// @dev Can be set to zero for immediate reveal after token mint
@@ -45,10 +45,13 @@ abstract contract BatchReveal is IBatchReveal {
     /// @param batchSeed The random number drawn
     event Reveal(uint256 batchNumber, uint256 batchSeed);
 
-    /// @dev BatchReveal constructor
+    /// @dev BatchReveal initialization
     /// @param _revealBatchSize Size of the batch reveal
     /// @param _collectionSize Needs to be sent by child contract
-    constructor(uint256 _revealBatchSize, uint256 _collectionSize) {
+    function initializeBatchReveal(
+        uint256 _revealBatchSize,
+        uint256 _collectionSize
+    ) internal {
         if (_collectionSize % _revealBatchSize != 0 || _revealBatchSize == 0) {
             revert Launchpeg__InvalidBatchRevealSize();
         }

--- a/contracts/FlatLaunchpeg.sol
+++ b/contracts/FlatLaunchpeg.sol
@@ -11,11 +11,11 @@ import "./BaseLaunchpeg.sol";
 contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     /// @notice Price of one NFT for people on the mint list
     /// @dev mintlistPrice is scaled to 1e18
-    uint256 public immutable override mintlistPrice;
+    uint256 public override mintlistPrice;
 
     /// @notice Price of one NFT during the public sale
     /// @dev salePrice is scaled to 1e18
-    uint256 public immutable override salePrice;
+    uint256 public override salePrice;
 
     /// @notice Determine wether or not users are allowed to buy from public sale
     bool public override isPublicSaleActive = false;
@@ -37,6 +37,13 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     event PublicSaleStateChanged(bool isActive);
 
     /// @dev FlatLaunchpeg constructor
+    /// Won't be used by the contract factory but is necessary for the ERC721A contract
+    /// name() and symbol() are overriden in BaseLaunchpeg
+    constructor(string memory _name, string memory _symbol)
+        ERC721A(_name, _symbol)
+    {}
+
+    /// @dev FlatLaunchpeg initialization
     /// @param _name ERC721 name
     /// @param _symbol ERC721 symbol
     /// @param _projectOwner The project owner
@@ -47,7 +54,7 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     /// @param _batchRevealSize Size of the batch reveal
     /// @param _salePrice Price of the public sale in Avax
     /// @param _mintlistPrice Price of the whitelist sale in Avax
-    constructor(
+    function initialize(
         string memory _name,
         string memory _symbol,
         address _projectOwner,
@@ -58,8 +65,8 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
         uint256 _batchRevealSize,
         uint256 _salePrice,
         uint256 _mintlistPrice
-    )
-        BaseLaunchpeg(
+    ) external {
+        initializeBaseLaunchpeg(
             _name,
             _symbol,
             _projectOwner,
@@ -68,8 +75,7 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
             _collectionSize,
             _amountForDevs,
             _batchRevealSize
-        )
-    {
+        );
         salePrice = _salePrice;
         mintlistPrice = _mintlistPrice;
     }

--- a/contracts/FlatLaunchpeg.sol
+++ b/contracts/FlatLaunchpeg.sol
@@ -36,13 +36,6 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     /// @param isActive True if the public sale is open, false otherwise
     event PublicSaleStateChanged(bool isActive);
 
-    /// @dev FlatLaunchpeg constructor
-    /// Won't be used by the contract factory but is necessary for the ERC721A contract
-    /// name() and symbol() are overriden in BaseLaunchpeg
-    constructor(string memory _name, string memory _symbol)
-        ERC721A(_name, _symbol)
-    {}
-
     /// @dev FlatLaunchpeg initialization
     /// @param _name ERC721 name
     /// @param _symbol ERC721 symbol
@@ -65,7 +58,7 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
         uint256 _batchRevealSize,
         uint256 _salePrice,
         uint256 _mintlistPrice
-    ) external {
+    ) external override initializer {
         initializeBaseLaunchpeg(
             _name,
             _symbol,
@@ -142,7 +135,7 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
         public
         view
         virtual
-        override(BaseLaunchpeg, IERC165)
+        override(BaseLaunchpeg, IERC165Upgradeable)
         returns (bool)
     {
         return

--- a/contracts/FlatLaunchpeg.sol
+++ b/contracts/FlatLaunchpeg.sol
@@ -36,7 +36,8 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     /// @param isActive True if the public sale is open, false otherwise
     event PublicSaleStateChanged(bool isActive);
 
-    /// @dev FlatLaunchpeg initialization
+    /// @notice FlatLaunchpeg initialization
+    /// Can only be called once
     /// @param _name ERC721 name
     /// @param _symbol ERC721 symbol
     /// @param _projectOwner The project owner

--- a/contracts/Launchpeg.sol
+++ b/contracts/Launchpeg.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-// import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
 

--- a/contracts/Launchpeg.sol
+++ b/contracts/Launchpeg.sol
@@ -137,7 +137,8 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
         _;
     }
 
-    /// @dev Launchpeg initialization
+    /// @notice Launchpeg initialization
+    /// Can only be called once
     /// @param _name ERC721 name
     /// @param _symbol ERC721 symbol
     /// @param _projectOwner The project owner

--- a/contracts/Launchpeg.sol
+++ b/contracts/Launchpeg.sol
@@ -18,11 +18,11 @@ import "./LaunchpegErrors.sol";
 contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
     /// @notice Amount of NFTs available for the auction (e.g 8000)
     /// Unsold items are put up for sale during the public sale.
-    uint256 public immutable override amountForAuction;
+    uint256 public override amountForAuction;
 
     /// @notice Amount of NFTs available for the allowList mint (e.g 1000)
     /// Unsold items are put up for sale during the public sale.
-    uint256 public immutable override amountForMintlist;
+    uint256 public override amountForMintlist;
 
     /// @notice Start time of the dutch auction in seconds
     /// @dev Timestamp
@@ -138,6 +138,13 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
     }
 
     /// @dev Launchpeg constructor
+    /// Won't be used by the contract factory but is necessary for the ERC721A contract
+    /// name() and symbol() are overriden in BaseLaunchpeg
+    constructor(string memory _name, string memory _symbol)
+        ERC721A(_name, _symbol)
+    {}
+
+    /// @dev Launchpeg initialization
     /// @param _name ERC721 name
     /// @param _symbol ERC721 symbol
     /// @param _projectOwner The project owner
@@ -148,7 +155,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
     /// @param _amountForMintlist Amount of NFTs available for the allowList mint (e.g 1000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
     /// @param _batchRevealSize Size of the batch reveal
-    constructor(
+    function initialize(
         string memory _name,
         string memory _symbol,
         address _projectOwner,
@@ -159,8 +166,8 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
         uint256 _amountForMintlist,
         uint256 _amountForDevs,
         uint256 _batchRevealSize
-    )
-        BaseLaunchpeg(
+    ) external {
+        initializeBaseLaunchpeg(
             _name,
             _symbol,
             _projectOwner,
@@ -169,8 +176,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
             _collectionSize,
             _amountForDevs,
             _batchRevealSize
-        )
-    {
+        );
         if (
             _amountForAuction + _amountForMintlist + _amountForDevs >
             _collectionSize

--- a/contracts/Launchpeg.sol
+++ b/contracts/Launchpeg.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
+// import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
 
-import "erc721a/contracts/ERC721A.sol";
+import "erc721a-upgradeable/contracts/ERC721AUpgradeable.sol";
 import "./BatchReveal.sol";
 
 import "./BaseLaunchpeg.sol";
@@ -137,13 +137,6 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
         _;
     }
 
-    /// @dev Launchpeg constructor
-    /// Won't be used by the contract factory but is necessary for the ERC721A contract
-    /// name() and symbol() are overriden in BaseLaunchpeg
-    constructor(string memory _name, string memory _symbol)
-        ERC721A(_name, _symbol)
-    {}
-
     /// @dev Launchpeg initialization
     /// @param _name ERC721 name
     /// @param _symbol ERC721 symbol
@@ -166,7 +159,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
         uint256 _amountForMintlist,
         uint256 _amountForDevs,
         uint256 _batchRevealSize
-    ) external {
+    ) external override initializer {
         initializeBaseLaunchpeg(
             _name,
             _symbol,
@@ -452,7 +445,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
         public
         view
         virtual
-        override(BaseLaunchpeg, IERC165)
+        override(BaseLaunchpeg, IERC165Upgradeable)
         returns (bool)
     {
         return

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+error LaunchpegFactory__InvalidImplementation();
 error Launchpeg__AuctionAlreadyInitialized();
 error Launchpeg__CanNotMintThisMany();
 error Launchpeg__CanOnlyMintMultipleOfMaxBatchSize();

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/proxy/Clones.sol";
+
+import "./interfaces/ILaunchpegFactory.sol";
+import "./interfaces/ILaunchpeg.sol";
+import "./interfaces/IFlatLaunchpeg.sol";
+
+/// @title Launchpeg Factory
+/// @author Trader Joe
+/// @notice Factory that creates Launchpeg contracts
+contract LaunchpegFactory is
+    ILaunchpegFactory,
+    Initializable,
+    OwnableUpgradeable
+{
+    address public override launchpegImplementation;
+    address public override flatLaunchpegImplementation;
+
+    uint256 public override joeFeePercent;
+    address public override joeFeeCollector;
+
+    mapping(address => bool) public override isLaunchpeg;
+    address[] public override allLaunchpegs;
+
+    /// @notice initializes the launchpeg factory
+    /// @dev Uses clone factory pattern to save space
+    function initialize(
+        address _launchpegImplementation,
+        address _flatLaunchpegImplementation,
+        uint256 _joeFeePercent,
+        address _joeFeeCollector
+    ) public initializer {
+        __Ownable_init();
+        launchpegImplementation = _launchpegImplementation;
+        flatLaunchpegImplementation = _flatLaunchpegImplementation;
+        joeFeePercent = _joeFeePercent;
+        joeFeeCollector = _joeFeeCollector;
+    }
+
+    /// @notice Returns the number of launch events
+    /// @return LaunchpegNumber The number of launch events ever created
+    function numLaunchpegs() external view override returns (uint256) {
+        return allLaunchpegs.length;
+    }
+
+    /// @dev Launchpeg creation
+    /// @param _name ERC721 name
+    /// @param _symbol ERC721 symbol
+    /// @param _projectOwner The project owner
+    /// @param _royaltyReceiver Royalty fee collector
+    /// @param _maxBatchSize Max amount of NFTs that can be minted at once
+    /// @param _collectionSize The collection size (e.g 10000)
+    /// @param _amountForAuction Amount of NFTs available for the auction (e.g 8000)
+    /// @param _amountForMintlist Amount of NFTs available for the allowList mint (e.g 1000)
+    /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
+    /// @param _batchRevealSize Size of the batch reveal
+    function createLaunchpeg(
+        string memory _name,
+        string memory _symbol,
+        address _projectOwner,
+        address _royaltyReceiver,
+        uint256 _maxBatchSize,
+        uint256 _collectionSize,
+        uint256 _amountForAuction,
+        uint256 _amountForMintlist,
+        uint256 _amountForDevs,
+        uint256 _batchRevealSize
+    ) external override onlyOwner returns (address) {
+        address launchpeg = Clones.clone(launchpegImplementation);
+
+        isLaunchpeg[launchpeg] = true;
+        allLaunchpegs.push(launchpeg);
+
+        ILaunchpeg(launchpeg).initialize(
+            _name,
+            _symbol,
+            _projectOwner,
+            _royaltyReceiver,
+            _maxBatchSize,
+            _collectionSize,
+            _amountForAuction,
+            _amountForMintlist,
+            _amountForDevs,
+            _batchRevealSize
+        );
+
+        IBaseLaunchpeg(launchpeg).initializeJoeFee(
+            joeFeePercent,
+            joeFeeCollector
+        );
+
+        OwnableUpgradeable(launchpeg).transferOwnership(msg.sender);
+
+        return launchpeg;
+    }
+
+    // @dev FlatLaunchpeg creation
+    /// @param _name ERC721 name
+    /// @param _symbol ERC721 symbol
+    /// @param _projectOwner The project owner
+    /// @param _royaltyReceiver Royalty fee collector
+    /// @param _maxBatchSize Max amount of NFTs that can be minted at once
+    /// @param _collectionSize The collection size (e.g 10000)
+    /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
+    /// @param _batchRevealSize Size of the batch reveal
+    /// @param _salePrice Price of the public sale in Avax
+    /// @param _mintlistPrice Price of the whitelist sale in Avax
+    function createFlatLaunchpeg(
+        string memory _name,
+        string memory _symbol,
+        address _projectOwner,
+        address _royaltyReceiver,
+        uint256 _maxBatchSize,
+        uint256 _collectionSize,
+        uint256 _amountForDevs,
+        uint256 _batchRevealSize,
+        uint256 _salePrice,
+        uint256 _mintlistPrice
+    ) external override onlyOwner returns (address) {
+        address flatLaunchpeg = Clones.clone(flatLaunchpegImplementation);
+
+        isLaunchpeg[flatLaunchpeg] = true;
+        allLaunchpegs.push(flatLaunchpeg);
+
+        IFlatLaunchpeg(flatLaunchpeg).initialize(
+            _name,
+            _symbol,
+            _projectOwner,
+            _royaltyReceiver,
+            _maxBatchSize,
+            _collectionSize,
+            _amountForDevs,
+            _batchRevealSize,
+            _salePrice,
+            _mintlistPrice
+        );
+
+        IBaseLaunchpeg(flatLaunchpeg).initializeJoeFee(
+            joeFeePercent,
+            joeFeeCollector
+        );
+
+        OwnableUpgradeable(flatLaunchpeg).transferOwnership(msg.sender);
+
+        return flatLaunchpeg;
+    }
+
+    /// @notice Set address for launchpegImplementation
+    /// @param _launchpegImplementation New launchpegImplementation
+    function setLaunchpegImplementation(address _launchpegImplementation)
+        external
+        override
+        onlyOwner
+    {
+        launchpegImplementation = _launchpegImplementation;
+    }
+
+    /// @notice Set address for flatLaunchpegImplementation
+    /// @param _flatLaunchpegImplementation New flatLaunchpegImplementation
+    function setFlatLaunchpegImplementation(
+        address _flatLaunchpegImplementation
+    ) external override onlyOwner {
+        flatLaunchpegImplementation = _flatLaunchpegImplementation;
+    }
+
+    /// @notice Set percentage of protocol fees
+    /// @param _joeFeePercent New joeFeePercent
+    function setDefaultJoeFeePercent(uint256 _joeFeePercent)
+        external
+        override
+        onlyOwner
+    {
+        joeFeePercent = _joeFeePercent;
+    }
+
+    /// @notice Set default address to collect protocol fees
+    /// @param _joeFeeCollector New collector address
+    function setDefaultJoeFeeCollector(address _joeFeeCollector)
+        external
+        override
+        onlyOwner
+    {
+        joeFeeCollector = _joeFeeCollector;
+    }
+}

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -18,16 +18,22 @@ contract LaunchpegFactory is
     Initializable,
     OwnableUpgradeable
 {
+    /// @notice Launchpeg contract to be cloned
     address public override launchpegImplementation;
+    /// @notice FlatLaunchpeg contract to be cloned
     address public override flatLaunchpegImplementation;
 
+    /// @notice Default fee percentage
     uint256 public override joeFeePercent;
+    /// @notice Default fee collector
     address public override joeFeeCollector;
 
+    /// @notice Checks if an address is stored as a Launchpeg
     mapping(address => bool) public override isLaunchpeg;
+    /// @notice Launchpegs address list
     address[] public override allLaunchpegs;
 
-    /// @notice initializes the launchpeg factory
+    /// @notice Initializes the Launchpeg factory
     /// @dev Uses clone factory pattern to save space
     /// @param _launchpegImplementation Launchpeg contract to be cloned
     /// @param _flatLaunchpegImplementation FlatLaunchpeg contract to be cloned
@@ -60,13 +66,13 @@ contract LaunchpegFactory is
         joeFeeCollector = _joeFeeCollector;
     }
 
-    /// @notice Returns the number of launch events
-    /// @return LaunchpegNumber The number of launch events ever created
+    /// @notice Returns the number of Launchpegs
+    /// @return LaunchpegNumber The number of Launchpegs ever created
     function numLaunchpegs() external view override returns (uint256) {
         return allLaunchpegs.length;
     }
 
-    /// @dev Launchpeg creation
+    /// @notice Launchpeg creation
     /// @param _name ERC721 name
     /// @param _symbol ERC721 symbol
     /// @param _projectOwner The project owner
@@ -77,6 +83,7 @@ contract LaunchpegFactory is
     /// @param _amountForMintlist Amount of NFTs available for the allowList mint (e.g 1000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
     /// @param _batchRevealSize Size of the batch reveal
+    /// @return launchpeg New Launchpeg address
     function createLaunchpeg(
         string memory _name,
         string memory _symbol,
@@ -131,7 +138,7 @@ contract LaunchpegFactory is
         return launchpeg;
     }
 
-    // @dev FlatLaunchpeg creation
+    /// @notice FlatLaunchpeg creation
     /// @param _name ERC721 name
     /// @param _symbol ERC721 symbol
     /// @param _projectOwner The project owner
@@ -142,6 +149,7 @@ contract LaunchpegFactory is
     /// @param _batchRevealSize Size of the batch reveal
     /// @param _salePrice Price of the public sale in Avax
     /// @param _mintlistPrice Price of the whitelist sale in Avax
+    /// @return flatLaunchpeg New FlatLaunchpeg address
     function createFlatLaunchpeg(
         string memory _name,
         string memory _symbol,

--- a/contracts/LaunchpegLens.sol
+++ b/contracts/LaunchpegLens.sol
@@ -6,7 +6,7 @@ import "./BaseLaunchpeg.sol";
 import "./interfaces/IFlatLaunchpeg.sol";
 import "./interfaces/ILaunchpeg.sol";
 import "./interfaces/IBatchReveal.sol";
-import "erc721a/contracts/ERC721A.sol";
+import "erc721a-upgradeable/contracts/ERC721AUpgradeable.sol";
 
 error LaunchpegLens__InvalidContract();
 
@@ -145,13 +145,14 @@ contract LaunchpegLens {
             revert LaunchpegLens__InvalidContract();
         }
 
-        data.collectionData.name = ERC721A(_launchpeg).name();
-        data.collectionData.symbol = ERC721A(_launchpeg).symbol();
+        data.collectionData.name = ERC721AUpgradeable(_launchpeg).name();
+        data.collectionData.symbol = ERC721AUpgradeable(_launchpeg).symbol();
         data.collectionData.collectionSize = BaseLaunchpeg(_launchpeg)
             .collectionSize();
         data.collectionData.maxBatchSize = BaseLaunchpeg(_launchpeg)
             .maxBatchSize();
-        data.collectionData.totalSupply = ERC721A(_launchpeg).totalSupply();
+        data.collectionData.totalSupply = ERC721AUpgradeable(_launchpeg)
+            .totalSupply();
 
         data.revealData.revealBatchSize = IBatchReveal(_launchpeg)
             .revealBatchSize();
@@ -214,7 +215,9 @@ contract LaunchpegLens {
         }
 
         if (_user != address(0)) {
-            data.userData.balanceOf = ERC721A(_launchpeg).balanceOf(_user);
+            data.userData.balanceOf = ERC721AUpgradeable(_launchpeg).balanceOf(
+                _user
+            );
             data.userData.allowanceForAllowlistMint = IBaseLaunchpeg(_launchpeg)
                 .allowList(_user);
         }

--- a/contracts/LaunchpegLens.sol
+++ b/contracts/LaunchpegLens.sol
@@ -89,6 +89,7 @@ contract LaunchpegLens {
     address public immutable launchpegFactory;
 
     /// @dev LaunchpegLens constructor
+    /// @param _launchpegFactory Address of the LaunchpegFactory
     constructor(address _launchpegFactory) {
         launchpegInterface = type(ILaunchpeg).interfaceId;
         flatLaunchpegInterface = type(IFlatLaunchpeg).interfaceId;
@@ -114,10 +115,9 @@ contract LaunchpegLens {
         }
     }
 
-    /// @notice Fetch Launchpeg data from a list of addresses
-    /// Will revert if a contract in the list is not a Launchpeg
-    /// @param _offset Index to start at when looking up launchpegs
-    /// @param _limit Maximum number of launchpegs datas to return
+    /// @notice Fetch Launchpeg data
+    /// @param _offset Index to start at when looking up Launchpegs
+    /// @param _limit Maximum number of Launchpegs datas to return
     /// @param _user Address to consider for NFT balances and mintlist allocations
     /// @return LensDataList List of contracts datas
     function getAllLaunchpegs(

--- a/contracts/interfaces/IBaseLaunchpeg.sol
+++ b/contracts/interfaces/IBaseLaunchpeg.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/IERC721MetadataUpgradeable.sol";
 
-import "erc721a/contracts/ERC721A.sol";
+import "erc721a-upgradeable/contracts/ERC721AUpgradeable.sol";
 
 /// @title IBaseLaunchpeg
 /// @author Trader Joe
 /// @notice Defines the basic interface of BaseLaunchpeg
-interface IBaseLaunchpeg is IERC721, IERC721Metadata {
+interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
     function collectionSize() external view returns (uint256);
 
     function amountForDevs() external view returns (uint256);
@@ -55,7 +55,7 @@ interface IBaseLaunchpeg is IERC721, IERC721Metadata {
     function getOwnershipData(uint256 tokenId)
         external
         view
-        returns (ERC721A.TokenOwnership memory);
+        returns (ERC721AUpgradeable.TokenOwnership memory);
 
     function numberMinted(address owner) external view returns (uint256);
 }

--- a/contracts/interfaces/IFlatLaunchpeg.sol
+++ b/contracts/interfaces/IFlatLaunchpeg.sol
@@ -13,6 +13,19 @@ interface IFlatLaunchpeg is IBaseLaunchpeg {
 
     function isPublicSaleActive() external view returns (bool);
 
+    function initialize(
+        string memory _name,
+        string memory _symbol,
+        address _projectOwner,
+        address _royaltyReceiver,
+        uint256 _maxBatchSize,
+        uint256 _collectionSize,
+        uint256 _amountForDevs,
+        uint256 _batchRevealSize,
+        uint256 _salePrice,
+        uint256 _mintlistPrice
+    ) external;
+
     function allowListMint(uint256 _quantity) external payable;
 
     function publicSaleMint(uint256 _quantity) external payable;

--- a/contracts/interfaces/ILaunchpeg.sol
+++ b/contracts/interfaces/ILaunchpeg.sol
@@ -42,6 +42,19 @@ interface ILaunchpeg is IBaseLaunchpeg {
 
     function lastAuctionPrice() external view returns (uint256);
 
+    function initialize(
+        string memory _name,
+        string memory _symbol,
+        address _projectOwner,
+        address _royaltyReceiver,
+        uint256 _maxBatchSize,
+        uint256 _collectionSize,
+        uint256 _amountForAuction,
+        uint256 _amountForMintlist,
+        uint256 _amountForDevs,
+        uint256 _batchRevealSize
+    ) external;
+
     function initializePhases(
         uint256 _auctionSaleStartTime,
         uint256 _auctionStartPrice,

--- a/contracts/interfaces/ILaunchpegFactory.sol
+++ b/contracts/interfaces/ILaunchpegFactory.sol
@@ -5,6 +5,41 @@ pragma solidity ^0.8.4;
 /// @author Trader Joe
 /// @notice Defines the basic interface of LaunchpegFactory
 interface ILaunchpegFactory {
+    event LaunchpegCreated(
+        address indexed launchpeg,
+        string name,
+        string symbol,
+        address indexed projectOwner,
+        address indexed royaltyReceiver,
+        uint256 maxBatchSize,
+        uint256 collectionSize,
+        uint256 amountForAuction,
+        uint256 amountForMintlist,
+        uint256 amountForDevs,
+        uint256 batchRevealSize
+    );
+
+    event FlatLaunchpegCreated(
+        address indexed flatLaunchpeg,
+        string name,
+        string symbol,
+        address indexed projectOwner,
+        address indexed royaltyReceiver,
+        uint256 maxBatchSize,
+        uint256 collectionSize,
+        uint256 amountForDevs,
+        uint256 batchRevealSize,
+        uint256 salePrice,
+        uint256 mintlistPrice
+    );
+
+    event SetLaunchpegImplementation(address indexed launchpegImplementation);
+    event SetFlatLaunchpegImplementation(
+        address indexed flatLaunchpegImplementation
+    );
+    event SetDefaultJoeFeePercent(uint256 joeFeePercent);
+    event SetDefaultJoeFeeCollector(address indexed joeFeeCollector);
+
     function launchpegImplementation() external view returns (address);
 
     function flatLaunchpegImplementation() external view returns (address);

--- a/contracts/interfaces/ILaunchpegFactory.sol
+++ b/contracts/interfaces/ILaunchpegFactory.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @title ILaunchpegFactory
+/// @author Trader Joe
+/// @notice Defines the basic interface of LaunchpegFactory
+interface ILaunchpegFactory {
+    function launchpegImplementation() external view returns (address);
+
+    function flatLaunchpegImplementation() external view returns (address);
+
+    function joeFeePercent() external view returns (uint256);
+
+    function joeFeeCollector() external view returns (address);
+
+    function isLaunchpeg(address _contract) external view returns (bool);
+
+    function allLaunchpegs(uint256 _launchpegID)
+        external
+        view
+        returns (address);
+
+    function numLaunchpegs() external view returns (uint256);
+
+    function createLaunchpeg(
+        string memory _name,
+        string memory _symbol,
+        address _projectOwner,
+        address _royaltyReceiver,
+        uint256 _maxBatchSize,
+        uint256 _collectionSize,
+        uint256 _amountForAuction,
+        uint256 _amountForMintlist,
+        uint256 _amountForDevs,
+        uint256 _batchRevealSize
+    ) external returns (address);
+
+    function createFlatLaunchpeg(
+        string memory _name,
+        string memory _symbol,
+        address _projectOwner,
+        address _royaltyReceiver,
+        uint256 _maxBatchSize,
+        uint256 _collectionSize,
+        uint256 _amountForDevs,
+        uint256 _batchRevealSize,
+        uint256 _salePrice,
+        uint256 _mintlistPrice
+    ) external returns (address);
+
+    function setLaunchpegImplementation(address _launchpegImplementation)
+        external;
+
+    function setFlatLaunchpegImplementation(
+        address _flatLaunchpegImplementation
+    ) external;
+
+    function setDefaultJoeFeePercent(uint256 _joeFeePercent) external;
+
+    function setDefaultJoeFeeCollector(address _joeFeeCollector) external;
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "chai": "^4.3.6",
     "dotenv": "^14.3.2",
     "erc721a": "^3.1.0",
+    "erc721a-upgradeable": "^3.2.0",
     "ethereum-waffle": "^3.1.1",
     "ethers": "^5.0.0",
     "hardhat": "^2.4.1",

--- a/test/FlatLaunchPeg.test.ts
+++ b/test/FlatLaunchPeg.test.ts
@@ -43,7 +43,7 @@ describe('FlatLaunchpeg', () => {
   })
 
   const deployFlatLaunchpeg = async () => {
-    flatLaunchpeg = await flatLaunchpegCF.deploy('JoePEG', 'JOEPEG')
+    flatLaunchpeg = await flatLaunchpegCF.deploy()
     await flatLaunchpeg.initialize(
       'JoePEG',
       'JOEPEG',

--- a/test/FlatLaunchPeg.test.ts
+++ b/test/FlatLaunchPeg.test.ts
@@ -43,7 +43,8 @@ describe('FlatLaunchpeg', () => {
   })
 
   const deployFlatLaunchpeg = async () => {
-    flatLaunchpeg = await flatLaunchpegCF.deploy(
+    flatLaunchpeg = await flatLaunchpegCF.deploy('JoePEG', 'JOEPEG')
+    await flatLaunchpeg.initialize(
       'JoePEG',
       'JOEPEG',
       projectOwner.address,

--- a/test/LaunchPeg.test.ts
+++ b/test/LaunchPeg.test.ts
@@ -44,7 +44,9 @@ describe('Launchpeg', () => {
   })
 
   const deployLaunchpeg = async () => {
-    launchpeg = await launchpegCF.deploy(
+    launchpeg = await launchpegCF.deploy('JoePEG', 'JOEPEG')
+
+    await launchpeg.initialize(
       'JoePEG',
       'JOEPEG',
       projectOwner.address,
@@ -73,8 +75,9 @@ describe('Launchpeg', () => {
     })
 
     it('Zero address should not be configurable as project owner', async () => {
+      launchpeg = await launchpegCF.deploy('JoePEG', 'JOEPEG')
       await expect(
-        launchpegCF.deploy(
+        launchpeg.initialize(
           'JoePEG',
           'JOEPEG',
           ethers.constants.AddressZero,

--- a/test/LaunchPeg.test.ts
+++ b/test/LaunchPeg.test.ts
@@ -44,7 +44,7 @@ describe('Launchpeg', () => {
   })
 
   const deployLaunchpeg = async () => {
-    launchpeg = await launchpegCF.deploy('JoePEG', 'JOEPEG')
+    launchpeg = await launchpegCF.deploy()
 
     await launchpeg.initialize(
       'JoePEG',
@@ -75,7 +75,7 @@ describe('Launchpeg', () => {
     })
 
     it('Zero address should not be configurable as project owner', async () => {
-      launchpeg = await launchpegCF.deploy('JoePEG', 'JOEPEG')
+      launchpeg = await launchpegCF.deploy()
       await expect(
         launchpeg.initialize(
           'JoePEG',
@@ -90,6 +90,19 @@ describe('Launchpeg', () => {
           config.batchRevealSize
         )
       ).to.be.revertedWith('Launchpeg__InvalidProjectOwner()')
+
+      launchpeg.initialize(
+        'JoePEG',
+        'JOEPEG',
+        projectOwner.address,
+        royaltyReceiver.address,
+        config.maxBatchSize,
+        config.collectionSize,
+        config.amountForAuction,
+        config.amountForMintlist,
+        config.amountForDevs,
+        config.batchRevealSize
+      )
 
       await expect(launchpeg.connect(dev).setProjectOwner(ethers.constants.AddressZero)).to.be.revertedWith(
         'Launchpeg__InvalidProjectOwner()'

--- a/test/LaunchPegFactory.test.ts
+++ b/test/LaunchPegFactory.test.ts
@@ -1,0 +1,187 @@
+import { config as hardhatConfig, ethers, network, upgrades } from 'hardhat'
+import { expect } from 'chai'
+import { getDefaultLaunchpegConfig, LaunchpegConfig } from './utils/helpers'
+import { ContractFactory, Contract } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+
+describe('LaunchpegFactory', () => {
+  let launchpegCF: ContractFactory
+  let flatLaunchpegCF: ContractFactory
+  let launchpegFactoryCF: ContractFactory
+  let launchpeg: Contract
+  let flatLaunchpeg: Contract
+  let launchpegFactory: Contract
+
+  let config: LaunchpegConfig
+
+  let signers: SignerWithAddress[]
+  let dev: SignerWithAddress
+  let alice: SignerWithAddress
+  let bob: SignerWithAddress
+  let projectOwner: SignerWithAddress
+  let royaltyReceiver: SignerWithAddress
+
+  before(async () => {
+    launchpegCF = await ethers.getContractFactory('Launchpeg')
+    flatLaunchpegCF = await ethers.getContractFactory('FlatLaunchpeg')
+    launchpegFactoryCF = await ethers.getContractFactory('LaunchpegFactory')
+
+    signers = await ethers.getSigners()
+    dev = signers[0]
+    alice = signers[1]
+    bob = signers[2]
+    projectOwner = signers[3]
+    royaltyReceiver = signers[4]
+
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: (hardhatConfig as any).networks.avalanche.url,
+          },
+          live: false,
+          saveDeployments: true,
+          tags: ['test', 'local'],
+        },
+      ],
+    })
+
+    config = { ...(await getDefaultLaunchpegConfig()) }
+    await deployLaunchpeg()
+    await deployFlatLaunchpeg()
+  })
+
+  const deployLaunchpeg = async () => {
+    launchpeg = await launchpegCF.deploy()
+
+    await launchpeg.initialize(
+      'JoePEG',
+      'JOEPEG',
+      projectOwner.address,
+      royaltyReceiver.address,
+      config.maxBatchSize,
+      config.collectionSize,
+      config.amountForAuction,
+      config.amountForMintlist,
+      config.amountForDevs,
+      config.batchRevealSize
+    )
+  }
+
+  const deployFlatLaunchpeg = async () => {
+    flatLaunchpeg = await flatLaunchpegCF.deploy()
+
+    await flatLaunchpeg.initialize(
+      'JoePEG',
+      'JOEPEG',
+      projectOwner.address,
+      royaltyReceiver.address,
+      config.maxBatchSize,
+      config.collectionSize,
+      config.amountForDevs,
+      config.batchRevealSize,
+      config.flatPublicSalePrice,
+      config.flatMintListSalePrice
+    )
+  }
+
+  const deployLaunchpegFactory = async () => {
+    launchpegFactory = await upgrades.deployProxy(launchpegFactoryCF, [
+      launchpeg.address,
+      flatLaunchpeg.address,
+      200,
+      royaltyReceiver.address,
+    ])
+    await launchpegFactory.deployed()
+  }
+
+  beforeEach(async () => {
+    await deployLaunchpegFactory()
+  })
+
+  describe('Launchpeg creation', () => {
+    it('Should increment the number of Launchpegs', async () => {
+      expect(await launchpegFactory.numLaunchpegs()).to.equal(0)
+
+      await launchpegFactory.createLaunchpeg(
+        'JoePEG',
+        'JOEPEG',
+        projectOwner.address,
+        royaltyReceiver.address,
+        config.maxBatchSize,
+        config.collectionSize,
+        config.amountForAuction,
+        config.amountForMintlist,
+        config.amountForDevs,
+        config.batchRevealSize
+      )
+
+      expect(await launchpegFactory.numLaunchpegs()).to.equal(1)
+    })
+
+    it('Should create FlatLaunchpegs as well', async () => {
+      expect(await launchpegFactory.numLaunchpegs()).to.equal(0)
+
+      await launchpegFactory.createFlatLaunchpeg(
+        'JoePEG',
+        'JOEPEG',
+        projectOwner.address,
+        royaltyReceiver.address,
+        config.maxBatchSize,
+        config.collectionSize,
+        config.amountForDevs,
+        config.batchRevealSize,
+        config.flatPublicSalePrice,
+        config.flatMintListSalePrice
+      )
+
+      expect(await launchpegFactory.numLaunchpegs()).to.equal(1)
+    })
+  })
+
+  describe('Factory configuration', () => {
+    it('Should set the new Launchpeg implementation', async () => {
+      const newAddress = '0x44c14d53D7B7672d7fD6E4A97fDA1A5f68F62aB6'
+      await launchpegFactory.setLaunchpegImplementation(newAddress)
+      expect(await launchpegFactory.launchpegImplementation()).to.equal(newAddress)
+    })
+
+    it('Should set the new FlatLaunchpeg implementation', async () => {
+      const newAddress = '0x44c14d53D7B7672d7fD6E4A97fDA1A5f68F62aB6'
+      await launchpegFactory.setFlatLaunchpegImplementation(newAddress)
+      expect(await launchpegFactory.flatLaunchpegImplementation()).to.equal(newAddress)
+    })
+
+    it('Should set the new fee configuration', async () => {
+      const newFees = 499
+      await launchpegFactory.setDefaultJoeFeePercent(newFees)
+      await launchpegFactory.setDefaultJoeFeeCollector(bob.address)
+
+      await launchpegFactory.createLaunchpeg(
+        'My new collection',
+        'JOEPEG',
+        projectOwner.address,
+        royaltyReceiver.address,
+        config.maxBatchSize,
+        config.collectionSize,
+        config.amountForAuction,
+        config.amountForMintlist,
+        config.amountForDevs,
+        config.batchRevealSize
+      )
+      const launchpeg0Address = await launchpegFactory.allLaunchpegs(0)
+      const launchpeg0 = await ethers.getContractAt('Launchpeg', launchpeg0Address)
+
+      expect(await launchpeg0.joeFeePercent()).to.equal(newFees)
+      expect(await launchpeg0.joeFeeCollector()).to.equal(bob.address)
+    })
+  })
+
+  after(async () => {
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [],
+    })
+  })
+})

--- a/test/LaunchPegFactory.test.ts
+++ b/test/LaunchPegFactory.test.ts
@@ -145,12 +145,18 @@ describe('LaunchpegFactory', () => {
       const newAddress = '0x44c14d53D7B7672d7fD6E4A97fDA1A5f68F62aB6'
       await launchpegFactory.setLaunchpegImplementation(newAddress)
       expect(await launchpegFactory.launchpegImplementation()).to.equal(newAddress)
+      await expect(launchpegFactory.setLaunchpegImplementation(ethers.constants.AddressZero)).to.be.revertedWith(
+        'LaunchpegFactory__InvalidImplementation()'
+      )
     })
 
     it('Should set the new FlatLaunchpeg implementation', async () => {
       const newAddress = '0x44c14d53D7B7672d7fD6E4A97fDA1A5f68F62aB6'
       await launchpegFactory.setFlatLaunchpegImplementation(newAddress)
       expect(await launchpegFactory.flatLaunchpegImplementation()).to.equal(newAddress)
+      await expect(launchpegFactory.setFlatLaunchpegImplementation(ethers.constants.AddressZero)).to.be.revertedWith(
+        'LaunchpegFactory__InvalidImplementation()'
+      )
     })
 
     it('Should set the new fee configuration', async () => {
@@ -175,6 +181,11 @@ describe('LaunchpegFactory', () => {
 
       expect(await launchpeg0.joeFeePercent()).to.equal(newFees)
       expect(await launchpeg0.joeFeeCollector()).to.equal(bob.address)
+
+      await expect(launchpegFactory.setDefaultJoeFeePercent(20_000)).to.be.revertedWith('Launchpeg__InvalidPercent()')
+      await expect(launchpegFactory.setDefaultJoeFeeCollector(ethers.constants.AddressZero)).to.be.revertedWith(
+        'Launchpeg__InvalidJoeFeeCollector()'
+      )
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,6 +782,11 @@
   resolved "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.2.tgz"
   integrity sha512-xgWZYaPlrEOQo3cBj97Ufiuv79SPd8Brh4GcFYhPgb6WvAq4ppz8dWKL6h+jLAK01rUqMRp/TS9AdXgAeNvCLA==
 
+"@openzeppelin/contracts-upgradeable@^4.4.2":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.6.0.tgz#1bf55f230f008554d4c6fe25eb165b85112108b0"
+  integrity sha512-5OnVuO4HlkjSCJO165a4i2Pu1zQGzMs//o54LPrwUgxvEO2P3ax1QuaSI0cEHHTveA77guS0PnNugpR2JMsPfA==
+
 "@openzeppelin/contracts@^4.4.1", "@openzeppelin/contracts@^4.4.2":
   version "4.5.0"
   resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.5.0.tgz"
@@ -3165,6 +3170,13 @@ env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
+
+erc721a-upgradeable@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/erc721a-upgradeable/-/erc721a-upgradeable-3.2.0.tgz#8b299cebf27282cd65bc47907e511bcaa33f38a8"
+  integrity sha512-5qrRsa0rLKsUjXcNTlVog0F7I1oFOsCjY6KS59JeIB6DBEGRBGihYBhL9q/i/UII5tOIVc7ZcpCvBnLg75OY9A==
+  dependencies:
+    "@openzeppelin/contracts-upgradeable" "^4.4.2"
 
 erc721a@^3.1.0:
   version "3.2.0"


### PR DESCRIPTION
We have a lot of `onlyOwner` functions in the contracts so I decided to transfer the Launchpeg ownership to the `createLaunchpeg` caller instead of keeping the Factory itself as the owner. I think the plan is to give ownership to the project owner at some point so it shouldn't be an issue but this is debatable, let me know if it doesn't sound right. Other solution would be to interface these functions inside the Factory.