### PR TITLE
audit issue 18 : fixing flatlaunchpeg reveal + adding safeguards

### DIFF
--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -130,7 +130,9 @@ abstract contract BaseLaunchpeg is
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _batchRevealSize
+        uint256 _batchRevealSize,
+        uint256 _revealStartTime,
+        uint256 _revealInterval
     ) internal onlyInitializing {
         __Ownable_init();
         __ERC721A_init(_name, _symbol);
@@ -144,6 +146,15 @@ abstract contract BaseLaunchpeg is
             revert Launchpeg__LargerCollectionSizeNeeded();
         }
 
+        // We assume that if the reveal is more than 100 days in the future, that's a mistake
+        // Same if the reveal interval is longer than 10 days
+        if (
+            _revealStartTime > block.timestamp + 8_640_000 ||
+            _revealInterval > 864_000
+        ) {
+            revert Launchpeg__InvalidRevealDates();
+        }
+
         projectOwner = _projectOwner;
         // Default royalty is 5%
         _setDefaultRoyalty(_royaltyReceiver, 500);
@@ -152,6 +163,9 @@ abstract contract BaseLaunchpeg is
         collectionSize = _collectionSize;
         maxPerAddressDuringMint = _maxBatchSize;
         amountForDevs = _amountForDevs;
+
+        revealStartTime = _revealStartTime;
+        revealInterval = _revealInterval;
     }
 
     /// @notice Initialize the sales fee percent taken by Joepegs and address that collects the fees

--- a/contracts/FlatLaunchpeg.sol
+++ b/contracts/FlatLaunchpeg.sol
@@ -45,9 +45,11 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     /// @param _maxBatchSize Max amount of NFTs that can be minted at once
     /// @param _collectionSize The collection size (e.g 10000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
-    /// @param _batchRevealSize Size of the batch reveal
     /// @param _salePrice Price of the public sale in Avax
     /// @param _mintlistPrice Price of the whitelist sale in Avax
+    /// @param _batchRevealSize Size of the batch reveal
+    /// @param _revealStartTime Start of the token URIs reveal in seconds
+    /// @param _revealInterval Interval between two batch reveals in seconds
     function initialize(
         string memory _name,
         string memory _symbol,
@@ -56,9 +58,11 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _batchRevealSize,
         uint256 _salePrice,
-        uint256 _mintlistPrice
+        uint256 _mintlistPrice,
+        uint256 _batchRevealSize,
+        uint256 _revealStartTime,
+        uint256 _revealInterval
     ) external override initializer {
         initializeBaseLaunchpeg(
             _name,
@@ -68,7 +72,9 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
             _maxBatchSize,
             _collectionSize,
             _amountForDevs,
-            _batchRevealSize
+            _batchRevealSize,
+            _revealStartTime,
+            _revealInterval
         );
         salePrice = _salePrice;
         mintlistPrice = _mintlistPrice;

--- a/contracts/Launchpeg.sol
+++ b/contracts/Launchpeg.sol
@@ -105,16 +105,6 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
         uint256 publicSaleDiscountPercent
     );
 
-    /// @dev Emitted on initializePhases()
-    /// @param revealStartTime Start of the token URIs reveal in seconds
-    /// @param revealInterval Interval between two batch reveals in seconds
-    /// @param revealBatchSize Amount of NFTs revealed in a single batch
-    event RevealInitialized(
-        uint256 revealStartTime,
-        uint256 revealInterval,
-        uint256 revealBatchSize
-    );
-
     /// @dev Emitted on auctionMint(), allowListMint(), publicSaleMint()
     /// @param sender The address that minted
     /// @param quantity Amount of NFTs minted
@@ -265,12 +255,6 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
             mintlistDiscountPercent,
             publicSaleStartTime,
             publicSaleDiscountPercent
-        );
-
-        emit RevealInitialized(
-            revealStartTime,
-            revealInterval,
-            revealBatchSize
         );
     }
 

--- a/contracts/Launchpeg.sol
+++ b/contracts/Launchpeg.sol
@@ -148,6 +148,8 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
     /// @param _amountForMintlist Amount of NFTs available for the allowList mint (e.g 1000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
     /// @param _batchRevealSize Size of the batch reveal
+    /// @param _revealStartTime Start of the token URIs reveal in seconds
+    /// @param _revealInterval Interval between two batch reveals in seconds
     function initialize(
         string memory _name,
         string memory _symbol,
@@ -158,7 +160,9 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
         uint256 _amountForAuction,
         uint256 _amountForMintlist,
         uint256 _amountForDevs,
-        uint256 _batchRevealSize
+        uint256 _batchRevealSize,
+        uint256 _revealStartTime,
+        uint256 _revealInterval
     ) external override initializer {
         initializeBaseLaunchpeg(
             _name,
@@ -168,7 +172,9 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
             _maxBatchSize,
             _collectionSize,
             _amountForDevs,
-            _batchRevealSize
+            _batchRevealSize,
+            _revealStartTime,
+            _revealInterval
         );
         if (
             _amountForAuction + _amountForMintlist + _amountForDevs >
@@ -191,8 +197,6 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
     /// @param _mintlistDiscountPercent Discount applied to the last auction price during the allowList mint
     /// @param _publicSaleStartTime Public sale start time in seconds
     /// @param _publicSaleDiscountPercent Discount applied to the last auction price during the public sale
-    /// @param _revealStartTime Start of the token URIs reveal in seconds
-    /// @param _revealInterval Interval between two batch reveals in seconds
     function initializePhases(
         uint256 _auctionSaleStartTime,
         uint256 _auctionStartPrice,
@@ -201,9 +205,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
         uint256 _mintlistStartTime,
         uint256 _mintlistDiscountPercent,
         uint256 _publicSaleStartTime,
-        uint256 _publicSaleDiscountPercent,
-        uint256 _revealStartTime,
-        uint256 _revealInterval
+        uint256 _publicSaleDiscountPercent
     ) external override atPhase(Phase.NotStarted) {
         if (auctionSaleStartTime != 0) {
             revert Launchpeg__AuctionAlreadyInitialized();
@@ -245,9 +247,6 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
 
         publicSaleStartTime = _publicSaleStartTime;
         publicSaleDiscountPercent = _publicSaleDiscountPercent;
-
-        revealStartTime = _revealStartTime;
-        revealInterval = _revealInterval;
 
         emit Initialized(
             name(),

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -14,6 +14,7 @@ error Launchpeg__InvalidBatchRevealSize();
 error Launchpeg__InvalidJoeFeeCollector();
 error Launchpeg__InvalidProjectOwner();
 error Launchpeg__InvalidPercent();
+error Launchpeg__InvalidRevealDates();
 error Launchpeg__LargerCollectionSizeNeeded();
 error Launchpeg__MaxSupplyForDevReached();
 error Launchpeg__MaxSupplyReached();

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -89,7 +89,9 @@ contract LaunchpegFactory is
     /// @param _amountForAuction Amount of NFTs available for the auction (e.g 8000)
     /// @param _amountForMintlist Amount of NFTs available for the allowList mint (e.g 1000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
-    /// @param _batchRevealSize Size of the batch reveal
+    /// @param _batchRevealData Contains batch reveal informations :
+    ///  Size of the batch reveal, start of the token URIs reveal in seconds
+    /// and interval between two batch reveals in seconds
     /// @return launchpeg New Launchpeg address
     function createLaunchpeg(
         string memory _name,
@@ -101,7 +103,7 @@ contract LaunchpegFactory is
         uint256 _amountForAuction,
         uint256 _amountForMintlist,
         uint256 _amountForDevs,
-        uint256 _batchRevealSize
+        BatchReveal calldata _batchRevealData
     ) external override onlyOwner returns (address) {
         address launchpeg = Clones.clone(launchpegImplementation);
 
@@ -118,7 +120,9 @@ contract LaunchpegFactory is
             _amountForAuction,
             _amountForMintlist,
             _amountForDevs,
-            _batchRevealSize
+            _batchRevealData.batchRevealSize,
+            _batchRevealData.revealStartTime,
+            _batchRevealData.revealInterval
         );
 
         IBaseLaunchpeg(launchpeg).initializeJoeFee(
@@ -139,7 +143,9 @@ contract LaunchpegFactory is
             _amountForAuction,
             _amountForMintlist,
             _amountForDevs,
-            _batchRevealSize
+            _batchRevealData.batchRevealSize,
+            _batchRevealData.revealStartTime,
+            _batchRevealData.revealInterval
         );
 
         return launchpeg;
@@ -153,9 +159,11 @@ contract LaunchpegFactory is
     /// @param _maxBatchSize Max amount of NFTs that can be minted at once
     /// @param _collectionSize The collection size (e.g 10000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
-    /// @param _batchRevealSize Size of the batch reveal
     /// @param _salePrice Price of the public sale in Avax
     /// @param _mintlistPrice Price of the whitelist sale in Avax
+    /// @param _batchRevealData Contains batch reveal informations :
+    ///  Size of the batch reveal, start of the token URIs reveal in seconds
+    /// and interval between two batch reveals in seconds
     /// @return flatLaunchpeg New FlatLaunchpeg address
     function createFlatLaunchpeg(
         string memory _name,
@@ -165,9 +173,9 @@ contract LaunchpegFactory is
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _batchRevealSize,
         uint256 _salePrice,
-        uint256 _mintlistPrice
+        uint256 _mintlistPrice,
+        BatchReveal calldata _batchRevealData
     ) external override onlyOwner returns (address) {
         address flatLaunchpeg = Clones.clone(flatLaunchpegImplementation);
 
@@ -182,9 +190,11 @@ contract LaunchpegFactory is
             _maxBatchSize,
             _collectionSize,
             _amountForDevs,
-            _batchRevealSize,
             _salePrice,
-            _mintlistPrice
+            _mintlistPrice,
+            _batchRevealData.batchRevealSize,
+            _batchRevealData.revealStartTime,
+            _batchRevealData.revealInterval
         );
 
         IBaseLaunchpeg(flatLaunchpeg).initializeJoeFee(
@@ -203,9 +213,11 @@ contract LaunchpegFactory is
             _maxBatchSize,
             _collectionSize,
             _amountForDevs,
-            _batchRevealSize,
             _salePrice,
-            _mintlistPrice
+            _mintlistPrice,
+            _batchRevealData.batchRevealSize,
+            _batchRevealData.revealStartTime,
+            _batchRevealData.revealInterval
         );
 
         return flatLaunchpeg;

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -18,6 +18,45 @@ contract LaunchpegFactory is
     Initializable,
     OwnableUpgradeable
 {
+    event LaunchpegCreated(
+        address indexed launchpeg,
+        string name,
+        string symbol,
+        address indexed projectOwner,
+        address indexed royaltyReceiver,
+        uint256 maxBatchSize,
+        uint256 collectionSize,
+        uint256 amountForAuction,
+        uint256 amountForMintlist,
+        uint256 amountForDevs,
+        uint256 batchRevealSize,
+        uint256 revealStartTime,
+        uint256 revealInterval
+    );
+
+    event FlatLaunchpegCreated(
+        address indexed flatLaunchpeg,
+        string name,
+        string symbol,
+        address indexed projectOwner,
+        address indexed royaltyReceiver,
+        uint256 maxBatchSize,
+        uint256 collectionSize,
+        uint256 amountForDevs,
+        uint256 salePrice,
+        uint256 mintlistPrice,
+        uint256 batchRevealSize,
+        uint256 revealStartTime,
+        uint256 revealInterval
+    );
+
+    event SetLaunchpegImplementation(address indexed launchpegImplementation);
+    event SetFlatLaunchpegImplementation(
+        address indexed flatLaunchpegImplementation
+    );
+    event SetDefaultJoeFeePercent(uint256 joeFeePercent);
+    event SetDefaultJoeFeeCollector(address indexed joeFeeCollector);
+
     /// @notice Launchpeg contract to be cloned
     address public override launchpegImplementation;
     /// @notice FlatLaunchpeg contract to be cloned

--- a/contracts/interfaces/IFlatLaunchpeg.sol
+++ b/contracts/interfaces/IFlatLaunchpeg.sol
@@ -22,6 +22,8 @@ interface IFlatLaunchpeg is IBaseLaunchpeg {
         uint256 _collectionSize,
         uint256 _amountForDevs,
         uint256 _batchRevealSize,
+        uint256 _revealStartTime,
+        uint256 _revealInterval,
         uint256 _salePrice,
         uint256 _mintlistPrice
     ) external;

--- a/contracts/interfaces/ILaunchpeg.sol
+++ b/contracts/interfaces/ILaunchpeg.sol
@@ -52,7 +52,9 @@ interface ILaunchpeg is IBaseLaunchpeg {
         uint256 _amountForAuction,
         uint256 _amountForMintlist,
         uint256 _amountForDevs,
-        uint256 _batchRevealSize
+        uint256 _batchRevealSize,
+        uint256 _revealStartTime,
+        uint256 _revealInterval
     ) external;
 
     function initializePhases(
@@ -63,9 +65,7 @@ interface ILaunchpeg is IBaseLaunchpeg {
         uint256 _mintlistStartTime,
         uint256 _mintlistDiscountPercent,
         uint256 _publicSaleStartTime,
-        uint256 _publicSaleDiscountPercent,
-        uint256 _revealStartTime,
-        uint256 _revealInterval
+        uint256 _publicSaleDiscountPercent
     ) external;
 
     function auctionMint(uint256 _quantity) external payable;

--- a/contracts/interfaces/ILaunchpegFactory.sol
+++ b/contracts/interfaces/ILaunchpegFactory.sol
@@ -5,6 +5,12 @@ pragma solidity ^0.8.4;
 /// @author Trader Joe
 /// @notice Defines the basic interface of LaunchpegFactory
 interface ILaunchpegFactory {
+    struct BatchReveal {
+        uint256 batchRevealSize;
+        uint256 revealStartTime;
+        uint256 revealInterval;
+    }
+
     event LaunchpegCreated(
         address indexed launchpeg,
         string name,
@@ -16,7 +22,9 @@ interface ILaunchpegFactory {
         uint256 amountForAuction,
         uint256 amountForMintlist,
         uint256 amountForDevs,
-        uint256 batchRevealSize
+        uint256 batchRevealSize,
+        uint256 revealStartTime,
+        uint256 revealInterval
     );
 
     event FlatLaunchpegCreated(
@@ -28,9 +36,11 @@ interface ILaunchpegFactory {
         uint256 maxBatchSize,
         uint256 collectionSize,
         uint256 amountForDevs,
-        uint256 batchRevealSize,
         uint256 salePrice,
-        uint256 mintlistPrice
+        uint256 mintlistPrice,
+        uint256 batchRevealSize,
+        uint256 revealStartTime,
+        uint256 revealInterval
     );
 
     event SetLaunchpegImplementation(address indexed launchpegImplementation);
@@ -73,7 +83,7 @@ interface ILaunchpegFactory {
         uint256 _amountForAuction,
         uint256 _amountForMintlist,
         uint256 _amountForDevs,
-        uint256 _batchRevealSize
+        BatchReveal calldata _batchRevealData
     ) external returns (address);
 
     function createFlatLaunchpeg(
@@ -84,9 +94,9 @@ interface ILaunchpegFactory {
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _batchRevealSize,
         uint256 _salePrice,
-        uint256 _mintlistPrice
+        uint256 _mintlistPrice,
+        BatchReveal calldata _batchRevealData
     ) external returns (address);
 
     function setLaunchpegImplementation(address _launchpegImplementation)

--- a/contracts/interfaces/ILaunchpegFactory.sol
+++ b/contracts/interfaces/ILaunchpegFactory.sol
@@ -11,45 +11,6 @@ interface ILaunchpegFactory {
         uint256 revealInterval;
     }
 
-    event LaunchpegCreated(
-        address indexed launchpeg,
-        string name,
-        string symbol,
-        address indexed projectOwner,
-        address indexed royaltyReceiver,
-        uint256 maxBatchSize,
-        uint256 collectionSize,
-        uint256 amountForAuction,
-        uint256 amountForMintlist,
-        uint256 amountForDevs,
-        uint256 batchRevealSize,
-        uint256 revealStartTime,
-        uint256 revealInterval
-    );
-
-    event FlatLaunchpegCreated(
-        address indexed flatLaunchpeg,
-        string name,
-        string symbol,
-        address indexed projectOwner,
-        address indexed royaltyReceiver,
-        uint256 maxBatchSize,
-        uint256 collectionSize,
-        uint256 amountForDevs,
-        uint256 salePrice,
-        uint256 mintlistPrice,
-        uint256 batchRevealSize,
-        uint256 revealStartTime,
-        uint256 revealInterval
-    );
-
-    event SetLaunchpegImplementation(address indexed launchpegImplementation);
-    event SetFlatLaunchpegImplementation(
-        address indexed flatLaunchpegImplementation
-    );
-    event SetDefaultJoeFeePercent(uint256 joeFeePercent);
-    event SetDefaultJoeFeeCollector(address indexed joeFeeCollector);
-
     function launchpegImplementation() external view returns (address);
 
     function flatLaunchpegImplementation() external view returns (address);

--- a/tasks/deploy-flatlaunchpeg.ts
+++ b/tasks/deploy-flatlaunchpeg.ts
@@ -24,9 +24,9 @@ task('deploy-flatlaunchpeg', 'Deploy FlatLaunchpeg contract')
       launchConfig.maxBatchSize,
       launchConfig.collectionSize,
       launchConfig.amountForDevs,
-      launchConfig.batchRevealSize,
       launchConfig.salePrice,
-      launchConfig.mintlistPrice
+      launchConfig.mintlistPrice,
+      [launchConfig.batchRevealSize, launchConfig.batchRevealStart, launchConfig.batchRevealInterval]
     )
 
     await creationTx.wait()

--- a/tasks/deploy-launchpeg.ts
+++ b/tasks/deploy-launchpeg.ts
@@ -27,7 +27,7 @@ task('deploy-launchpeg', 'Deploy Launchpeg contract')
       launchConfig.amountForAuction,
       launchConfig.amountForMintlist,
       launchConfig.amountForDevs,
-      launchConfig.batchRevealSize
+      [launchConfig.batchRevealSize, launchConfig.batchRevealStart, launchConfig.batchRevealInterval]
     )
 
     await creationTx.wait()
@@ -49,9 +49,7 @@ task('deploy-launchpeg', 'Deploy Launchpeg contract')
       launchConfig.mintlistStartTime,
       launchConfig.mintlistDiscountPercent,
       launchConfig.publicSaleStartTime,
-      launchConfig.publicSaleDiscountPercent,
-      launchConfig.revealStartTime,
-      launchConfig.revealInterval
+      launchConfig.publicSaleDiscountPercent
     )
 
     await initTx.wait()

--- a/test/FlatLaunchPeg.test.ts
+++ b/test/FlatLaunchPeg.test.ts
@@ -52,9 +52,11 @@ describe('FlatLaunchpeg', () => {
       config.maxBatchSize,
       config.collectionSize,
       config.amountForDevs,
-      config.batchRevealSize,
       config.flatPublicSalePrice,
-      config.flatMintListSalePrice
+      config.flatMintListSalePrice,
+      config.batchRevealSize,
+      config.batchRevealStart,
+      config.batchRevealInterval
     )
   }
 

--- a/test/LaunchPeg.test.ts
+++ b/test/LaunchPeg.test.ts
@@ -56,7 +56,9 @@ describe('Launchpeg', () => {
       config.amountForAuction,
       config.amountForMintlist,
       config.amountForDevs,
-      config.batchRevealSize
+      config.batchRevealSize,
+      config.batchRevealStart,
+      config.batchRevealInterval
     )
   }
 
@@ -87,7 +89,9 @@ describe('Launchpeg', () => {
           config.amountForAuction,
           config.amountForMintlist,
           config.amountForDevs,
-          config.batchRevealSize
+          config.batchRevealSize,
+          config.batchRevealStart,
+          config.batchRevealInterval
         )
       ).to.be.revertedWith('Launchpeg__InvalidProjectOwner()')
 
@@ -101,7 +105,9 @@ describe('Launchpeg', () => {
         config.amountForAuction,
         config.amountForMintlist,
         config.amountForDevs,
-        config.batchRevealSize
+        config.batchRevealSize,
+        config.batchRevealStart,
+        config.batchRevealInterval
       )
 
       await expect(launchpeg.connect(dev).setProjectOwner(ethers.constants.AddressZero)).to.be.revertedWith(
@@ -159,6 +165,44 @@ describe('Launchpeg', () => {
       await expect(initializePhases(launchpeg, config, Phase.DutchAuction)).to.be.revertedWith(
         'Launchpeg__InvalidPercent()'
       )
+    })
+
+    it('Batch reveal dates must be coherent', async () => {
+      launchpeg = await launchpegCF.deploy()
+
+      await expect(
+        launchpeg.initialize(
+          'JoePEG',
+          'JOEPEG',
+          projectOwner.address,
+          royaltyReceiver.address,
+          config.maxBatchSize,
+          config.collectionSize,
+          config.amountForAuction,
+          config.amountForMintlist,
+          config.amountForDevs,
+          config.batchRevealSize,
+          config.batchRevealStart.add(8_640_000),
+          config.batchRevealInterval
+        )
+      ).to.be.revertedWith('Launchpeg__InvalidRevealDates()')
+
+      await expect(
+        launchpeg.initialize(
+          'JoePEG',
+          'JOEPEG',
+          projectOwner.address,
+          royaltyReceiver.address,
+          config.maxBatchSize,
+          config.collectionSize,
+          config.amountForAuction,
+          config.amountForMintlist,
+          config.amountForDevs,
+          config.batchRevealSize,
+          config.batchRevealStart,
+          config.batchRevealInterval.add(864_000)
+        )
+      ).to.be.revertedWith('Launchpeg__InvalidRevealDates()')
     })
   })
 

--- a/test/LaunchPegFactory.test.ts
+++ b/test/LaunchPegFactory.test.ts
@@ -65,7 +65,9 @@ describe('LaunchpegFactory', () => {
       config.amountForAuction,
       config.amountForMintlist,
       config.amountForDevs,
-      config.batchRevealSize
+      config.batchRevealSize,
+      config.batchRevealStart,
+      config.batchRevealInterval
     )
   }
 
@@ -80,9 +82,11 @@ describe('LaunchpegFactory', () => {
       config.maxBatchSize,
       config.collectionSize,
       config.amountForDevs,
-      config.batchRevealSize,
       config.flatPublicSalePrice,
-      config.flatMintListSalePrice
+      config.flatMintListSalePrice,
+      config.batchRevealSize,
+      config.batchRevealStart,
+      config.batchRevealInterval
     )
   }
 
@@ -114,7 +118,7 @@ describe('LaunchpegFactory', () => {
         config.amountForAuction,
         config.amountForMintlist,
         config.amountForDevs,
-        config.batchRevealSize
+        [config.batchRevealSize, config.batchRevealStart, config.batchRevealInterval]
       )
 
       expect(await launchpegFactory.numLaunchpegs(0)).to.equal(1)
@@ -131,9 +135,9 @@ describe('LaunchpegFactory', () => {
         config.maxBatchSize,
         config.collectionSize,
         config.amountForDevs,
-        config.batchRevealSize,
         config.flatPublicSalePrice,
-        config.flatMintListSalePrice
+        config.flatMintListSalePrice,
+        [config.batchRevealSize, config.batchRevealStart, config.batchRevealInterval]
       )
 
       expect(await launchpegFactory.numLaunchpegs(1)).to.equal(1)
@@ -174,7 +178,7 @@ describe('LaunchpegFactory', () => {
         config.amountForAuction,
         config.amountForMintlist,
         config.amountForDevs,
-        config.batchRevealSize
+        [config.batchRevealSize, config.batchRevealStart, config.batchRevealInterval]
       )
       const launchpeg0Address = await launchpegFactory.allLaunchpegs(0, 0)
       const launchpeg0 = await ethers.getContractAt('Launchpeg', launchpeg0Address)

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -72,9 +72,7 @@ export const initializePhases = async (launchpeg: Contract, config: LaunchpegCon
     config.mintlistStartTime,
     config.mintlistDiscount,
     config.publicSaleStartTime,
-    config.publicSaleDiscount,
-    config.batchRevealStart,
-    config.batchRevealInterval
+    config.publicSaleDiscount
   )
   await launchpeg.setUnrevealedURI(config.unrevealedTokenURI)
   await launchpeg.setBaseURI(config.baseTokenURI)


### PR DESCRIPTION
Reveal dates for FlatLaunchpeg were actually never initialised. I moved the logic into BaseLaunchpeg to have the same for Launchpeg and FlatLaunchpeg, so for Launchpeg, the reveal setup is now in `initialize` and not in `initializePhases` anymore.

I used a struct in the factory to avoid stack too deep errors.