### PR TITLE
Feature/launchpeg v2

### DIFF
--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -377,13 +377,14 @@ abstract contract BaseLaunchpeg is
         if (amountMintedByDevs + _quantity > amountForDevs) {
             revert Launchpeg__MaxSupplyForDevReached();
         }
-        if (_quantity % maxBatchSize != 0) {
-            revert Launchpeg__CanOnlyMintMultipleOfMaxBatchSize();
-        }
         amountMintedByDevs = amountMintedByDevs + _quantity;
         uint256 numChunks = _quantity / maxBatchSize;
         for (uint256 i; i < numChunks; i++) {
             _mint(msg.sender, maxBatchSize, "", false);
+        }
+        uint256 remainingQty = _quantity % maxBatchSize;
+        if (remainingQty != 0) {
+            _mint(msg.sender, remainingQty, "", false);
         }
         emit DevMint(msg.sender, _quantity);
     }

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -133,28 +133,16 @@ abstract contract BaseLaunchpeg is
     );
 
     /// @dev Emitted on setAllowlistStartTime()
-    /// @param oldAllowlistStartTime old allowlist start time
-    /// @param newAllowlistStartTime new allowlist start time
-    event AllowlistStartTimeSet(
-        uint256 oldAllowlistStartTime,
-        uint256 newAllowlistStartTime
-    );
+    /// @param allowlistStartTime New allowlist start time
+    event AllowlistStartTimeSet(uint256 allowlistStartTime);
 
     /// @dev Emitted on setPublicSaleStartTime()
-    /// @param oldPublicSaleStartTime old public sale start time
-    /// @param newPublicSaleStartTime new public sale start time
-    event PublicSaleStartTimeSet(
-        uint256 oldPublicSaleStartTime,
-        uint256 newPublicSaleStartTime
-    );
+    /// @param publicSaleStartTime New public sale start time
+    event PublicSaleStartTimeSet(uint256 publicSaleStartTime);
 
     /// @dev Emitted on setPublicSaleEndTime()
-    /// @param oldPublicSaleEndTime old public sale end time
-    /// @param newPublicSaleEndTime new public sale end time
-    event PublicSaleEndTimeSet(
-        uint256 oldPublicSaleEndTime,
-        uint256 newPublicSaleEndTime
-    );
+    /// @param publicSaleEndTime New public sale end time
+    event PublicSaleEndTimeSet(uint256 publicSaleEndTime);
 
     modifier isEOA() {
         if (tx.origin != msg.sender) {
@@ -398,7 +386,7 @@ abstract contract BaseLaunchpeg is
     /// @notice Set the public sale start time. Can only be set after phases
     /// have been initialized.
     /// @dev Only callable by owner
-    /// @param _publicSaleStartTime new public sale start time
+    /// @param _publicSaleStartTime New public sale start time
     function setPublicSaleStartTime(uint256 _publicSaleStartTime)
         external
         override
@@ -409,7 +397,7 @@ abstract contract BaseLaunchpeg is
 
     /// @notice Set the public sale start time. Can only be set after phases
     /// have been initialized.
-    /// @param _publicSaleStartTime new public sale start time
+    /// @param _publicSaleStartTime New public sale start time
     function _setPublicSaleStartTime(uint256 _publicSaleStartTime) private {
         if (publicSaleStartTime == 0) {
             revert Launchpeg__NotInitialized();
@@ -420,15 +408,14 @@ abstract contract BaseLaunchpeg is
         if (publicSaleEndTime < _publicSaleStartTime) {
             revert Launchpeg__PublicSaleEndBeforePublicSaleStart();
         }
-        uint256 oldPublicSaleStartTime = publicSaleStartTime;
         publicSaleStartTime = _publicSaleStartTime;
-        emit PublicSaleStartTimeSet(oldPublicSaleStartTime, _publicSaleStartTime);
+        emit PublicSaleStartTimeSet(_publicSaleStartTime);
     }
 
     /// @notice Set the public sale end time. Can only be set after phases
     /// have been initialized.
     /// @dev Only callable by owner
-    /// @param _publicSaleEndTime new public sale end time
+    /// @param _publicSaleEndTime New public sale end time
     function setPublicSaleEndTime(uint256 _publicSaleEndTime)
         external
         override
@@ -439,7 +426,7 @@ abstract contract BaseLaunchpeg is
 
     /// @notice Set the public sale end time. Can only be set after phases
     /// have been initialized.
-    /// @param _publicSaleEndTime new public sale end time
+    /// @param _publicSaleEndTime New public sale end time
     function _setPublicSaleEndTime(uint256 _publicSaleEndTime) private {
         if (publicSaleEndTime == 0) {
             revert Launchpeg__NotInitialized();
@@ -447,9 +434,8 @@ abstract contract BaseLaunchpeg is
         if (_publicSaleEndTime < publicSaleStartTime) {
             revert Launchpeg__PublicSaleEndBeforePublicSaleStart();
         }
-        uint256 oldPublicSaleEndTime = publicSaleEndTime;
         publicSaleEndTime = _publicSaleEndTime;
-        emit PublicSaleEndTimeSet(oldPublicSaleEndTime, _publicSaleEndTime);
+        emit PublicSaleEndTimeSet(_publicSaleEndTime);
     }
 
     /// @notice Mint NFTs to the project owner

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -80,6 +80,10 @@ abstract contract BaseLaunchpeg is
     /// @dev A timestamp greater than the allowlist mint start
     uint256 public override publicSaleStartTime;
 
+    /// @notice End time of the public sale in seconds
+    /// @dev A timestamp greater than the public sale start
+    uint256 public override publicSaleEndTime;
+
     /// @dev Emitted on initializeJoeFee()
     /// @param feePercent The fees collected by Joepegs on the sale benefits
     /// @param feeCollector The address to which the fees on the sale will be sent

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -410,7 +410,7 @@ abstract contract BaseLaunchpeg is
     /// @notice Set the public sale start time. Can only be set after phases
     /// have been initialized.
     /// @param _publicSaleStartTime new public sale start time
-    function _setPublicSaleStartTime(uint256 _publicSaleStartTime) internal {
+    function _setPublicSaleStartTime(uint256 _publicSaleStartTime) private {
         if (publicSaleStartTime == 0) {
             revert Launchpeg__NotInitialized();
         }
@@ -440,7 +440,7 @@ abstract contract BaseLaunchpeg is
     /// @notice Set the public sale end time. Can only be set after phases
     /// have been initialized.
     /// @param _publicSaleEndTime new public sale end time
-    function _setPublicSaleEndTime(uint256 _publicSaleEndTime) internal {
+    function _setPublicSaleEndTime(uint256 _publicSaleEndTime) private {
         if (publicSaleEndTime == 0) {
             revert Launchpeg__NotInitialized();
         }

--- a/contracts/FlatLaunchpeg.sol
+++ b/contracts/FlatLaunchpeg.sol
@@ -152,7 +152,7 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     /// @notice Set the allowlist start time. Can only be set after phases
     /// have been initialized.
     /// @param _allowlistStartTime new allowlist start time
-    function _setAllowlistStartTime(uint256 _allowlistStartTime) internal {
+    function _setAllowlistStartTime(uint256 _allowlistStartTime) private {
         if (allowlistStartTime == 0) {
             revert Launchpeg__NotInitialized();
         }

--- a/contracts/FlatLaunchpeg.sol
+++ b/contracts/FlatLaunchpeg.sol
@@ -140,7 +140,7 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     /// @notice Set the allowlist start time. Can only be set after phases
     /// have been initialized.
     /// @dev Only callable by owner
-    /// @param _allowlistStartTime new allowlist start time
+    /// @param _allowlistStartTime New allowlist start time
     function setAllowlistStartTime(uint256 _allowlistStartTime)
         external
         override
@@ -151,7 +151,7 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
 
     /// @notice Set the allowlist start time. Can only be set after phases
     /// have been initialized.
-    /// @param _allowlistStartTime new allowlist start time
+    /// @param _allowlistStartTime New allowlist start time
     function _setAllowlistStartTime(uint256 _allowlistStartTime) private {
         if (allowlistStartTime == 0) {
             revert Launchpeg__NotInitialized();
@@ -162,9 +162,8 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
         if (publicSaleStartTime < _allowlistStartTime) {
             revert Launchpeg__PublicSaleBeforeAllowlist();
         }
-        uint256 oldAllowlistStartTime = allowlistStartTime;
         allowlistStartTime = _allowlistStartTime;
-        emit AllowlistStartTimeSet(oldAllowlistStartTime, _allowlistStartTime);
+        emit AllowlistStartTimeSet(_allowlistStartTime);
     }
 
     /// @notice Mint NFTs during the allowlist mint

--- a/contracts/FlatLaunchpeg.sol
+++ b/contracts/FlatLaunchpeg.sol
@@ -19,11 +19,13 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     /// @dev Emitted on initializePhases()
     /// @param allowlistStartTime Allowlist mint start time in seconds
     /// @param publicSaleStartTime Public sale start time in seconds
+    /// @param publicSaleEndTime Public sale end time in seconds
     /// @param allowlistPrice Price of the allowlist sale in Avax
     /// @param salePrice Price of the public sale in Avax
     event Initialized(
         uint256 allowlistStartTime,
         uint256 publicSaleStartTime,
+        uint256 publicSaleEndTime,
         uint256 allowlistPrice,
         uint256 salePrice
     );
@@ -96,11 +98,13 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     /// @dev Can only be called once
     /// @param _allowlistStartTime Allowlist mint start time in seconds
     /// @param _publicSaleStartTime Public sale start time in seconds
+    /// @param _publicSaleEndTime Public sale end time in seconds
     /// @param _allowlistPrice Price of the allowlist sale in Avax
     /// @param _salePrice Price of the public sale in Avax
     function initializePhases(
         uint256 _allowlistStartTime,
         uint256 _publicSaleStartTime,
+        uint256 _publicSaleEndTime,
         uint256 _allowlistPrice,
         uint256 _salePrice
     ) external override onlyOwner atPhase(Phase.NotStarted) {
@@ -109,6 +113,9 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
         }
         if (_publicSaleStartTime < _allowlistStartTime) {
             revert Launchpeg__PublicSaleBeforeAllowlist();
+        }
+        if (_publicSaleEndTime < _publicSaleStartTime) {
+            revert Launchpeg__PublicSaleEndBeforePublicSaleStart();
         }
         if (_allowlistPrice > _salePrice) {
             revert Launchpeg__InvalidAllowlistPrice();
@@ -119,10 +126,12 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
 
         allowlistStartTime = _allowlistStartTime;
         publicSaleStartTime = _publicSaleStartTime;
+        publicSaleEndTime = _publicSaleEndTime;
 
         emit Initialized(
             allowlistStartTime,
             publicSaleStartTime,
+            publicSaleEndTime,
             allowlistPrice,
             salePrice
         );
@@ -188,6 +197,7 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
         if (
             allowlistStartTime == 0 ||
             publicSaleStartTime == 0 ||
+            publicSaleEndTime == 0 ||
             block.timestamp < allowlistStartTime
         ) {
             return Phase.NotStarted;
@@ -196,8 +206,13 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
             block.timestamp < publicSaleStartTime
         ) {
             return Phase.Allowlist;
+        } else if (
+            block.timestamp >= publicSaleStartTime &&
+            block.timestamp < publicSaleEndTime
+        ) {
+            return Phase.PublicSale;
         }
-        return Phase.PublicSale;
+        return Phase.Ended;
     }
 
     /// @dev Returns true if this contract implements the interface defined by

--- a/contracts/Launchpeg.sol
+++ b/contracts/Launchpeg.sol
@@ -253,7 +253,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
     /// @notice Set the auction sale start time. Can only be set after phases
     /// have been initialized.
     /// @param _auctionSaleStartTime new auction sale start time
-    function _setAuctionSaleStartTime(uint256 _auctionSaleStartTime) internal {
+    function _setAuctionSaleStartTime(uint256 _auctionSaleStartTime) private {
         if (auctionSaleStartTime == 0) {
             revert Launchpeg__NotInitialized();
         }
@@ -283,7 +283,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
     /// @notice Set the allowlist start time. Can only be set after phases
     /// have been initialized.
     /// @param _allowlistStartTime new allowlist start time
-    function _setAllowlistStartTime(uint256 _allowlistStartTime) internal {
+    function _setAllowlistStartTime(uint256 _allowlistStartTime) private {
         if (allowlistStartTime == 0) {
             revert Launchpeg__NotInitialized();
         }

--- a/contracts/Launchpeg.sol
+++ b/contracts/Launchpeg.sol
@@ -75,12 +75,8 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
     );
 
     /// @dev Emitted on setAuctionSaleStartTime()
-    /// @param oldAuctionSaleStartTime old auction sale start time
-    /// @param newAuctionSaleStartTime new auction sale start time
-    event AuctionSaleStartTimeSet(
-        uint256 oldAuctionSaleStartTime,
-        uint256 newAuctionSaleStartTime
-    );
+    /// @param auctionSaleStartTime New auction sale start time
+    event AuctionSaleStartTimeSet(uint256 auctionSaleStartTime);
 
     /// @dev Emitted on auctionMint(), allowlistMint(), publicSaleMint()
     /// @param sender The address that minted
@@ -241,7 +237,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
     /// @notice Set the auction sale start time. Can only be set after phases
     /// have been initialized.
     /// @dev Only callable by owner
-    /// @param _auctionSaleStartTime new auction sale start time
+    /// @param _auctionSaleStartTime New auction sale start time
     function setAuctionSaleStartTime(uint256 _auctionSaleStartTime)
         external
         override
@@ -252,7 +248,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
 
     /// @notice Set the auction sale start time. Can only be set after phases
     /// have been initialized.
-    /// @param _auctionSaleStartTime new auction sale start time
+    /// @param _auctionSaleStartTime New auction sale start time
     function _setAuctionSaleStartTime(uint256 _auctionSaleStartTime) private {
         if (auctionSaleStartTime == 0) {
             revert Launchpeg__NotInitialized();
@@ -263,15 +259,14 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
         if (allowlistStartTime <= _auctionSaleStartTime) {
             revert Launchpeg__AllowlistBeforeAuction();
         }
-        uint256 oldAuctionSaleStartTime = auctionSaleStartTime;
         auctionSaleStartTime = _auctionSaleStartTime;
-        emit AuctionSaleStartTimeSet(oldAuctionSaleStartTime, _auctionSaleStartTime);
+        emit AuctionSaleStartTimeSet(_auctionSaleStartTime);
     }
 
     /// @notice Set the allowlist start time. Can only be set after phases
     /// have been initialized.
     /// @dev Only callable by owner
-    /// @param _allowlistStartTime new allowlist start time
+    /// @param _allowlistStartTime New allowlist start time
     function setAllowlistStartTime(uint256 _allowlistStartTime)
         external
         override
@@ -282,7 +277,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
 
     /// @notice Set the allowlist start time. Can only be set after phases
     /// have been initialized.
-    /// @param _allowlistStartTime new allowlist start time
+    /// @param _allowlistStartTime New allowlist start time
     function _setAllowlistStartTime(uint256 _allowlistStartTime) private {
         if (allowlistStartTime == 0) {
             revert Launchpeg__NotInitialized();
@@ -293,9 +288,8 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
         if (publicSaleStartTime < _allowlistStartTime) {
             revert Launchpeg__PublicSaleBeforeAllowlist();
         }
-        uint256 oldAllowlistStartTime = allowlistStartTime;
         allowlistStartTime = _allowlistStartTime;
-        emit AllowlistStartTimeSet(oldAllowlistStartTime, _allowlistStartTime);
+        emit AllowlistStartTimeSet(_allowlistStartTime);
     }
 
     /// @notice Mint NFTs during the dutch auction

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -27,6 +27,7 @@ error Launchpeg__MaxSupplyReached();
 error Launchpeg__AllowlistBeforeAuction();
 error Launchpeg__NotEligibleForAllowlistMint();
 error Launchpeg__NotEnoughAVAX(uint256 avaxSent);
+error Launchpeg__NotInitialized();
 error Launchpeg__PublicSaleBeforeAllowlist();
 error Launchpeg__PublicSaleEndBeforePublicSaleStart();
 error Launchpeg__RevealNextBatchNotAvailable();

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -28,6 +28,7 @@ error Launchpeg__AllowlistBeforeAuction();
 error Launchpeg__NotEligibleForAllowlistMint();
 error Launchpeg__NotEnoughAVAX(uint256 avaxSent);
 error Launchpeg__PublicSaleBeforeAllowlist();
+error Launchpeg__PublicSaleEndBeforePublicSaleStart();
 error Launchpeg__RevealNextBatchNotAvailable();
 error Launchpeg__TransferFailed();
 error Launchpeg__Unauthorized();

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.4;
 
 error LaunchpegFactory__InvalidImplementation();
 error Launchpeg__CanNotMintThisMany();
-error Launchpeg__CanOnlyMintMultipleOfMaxBatchSize();
 error Launchpeg__EndPriceGreaterThanStartPrice();
 error Launchpeg__HasBeenForceRevealed();
 error Launchpeg__JoeFeeAlreadyInitialized();

--- a/contracts/interfaces/IBaseLaunchpeg.sol
+++ b/contracts/interfaces/IBaseLaunchpeg.sol
@@ -14,7 +14,8 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
         NotStarted,
         DutchAuction,
         Allowlist,
-        PublicSale
+        PublicSale,
+        Ended
     }
 
     function collectionSize() external view returns (uint256);
@@ -48,6 +49,8 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
     function allowlistStartTime() external view returns (uint256);
 
     function publicSaleStartTime() external view returns (uint256);
+
+    function publicSaleEndTime() external view returns (uint256);
 
     function initializeJoeFee(uint256 _joeFeePercent, address _joeFeeCollector)
         external;

--- a/contracts/interfaces/IBaseLaunchpeg.sol
+++ b/contracts/interfaces/IBaseLaunchpeg.sol
@@ -75,6 +75,8 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
         uint32 _callbackGasLimit
     ) external;
 
+    function setPublicSaleEndTime(uint256 _publicSaleEndTime) external;
+
     function devMint(uint256 quantity) external;
 
     function withdrawAVAX(address to) external;

--- a/contracts/interfaces/IBaseLaunchpeg.sol
+++ b/contracts/interfaces/IBaseLaunchpeg.sol
@@ -75,6 +75,8 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
         uint32 _callbackGasLimit
     ) external;
 
+    function setPublicSaleStartTime(uint256 _publicSaleStartTime) external;
+
     function setPublicSaleEndTime(uint256 _publicSaleEndTime) external;
 
     function devMint(uint256 quantity) external;

--- a/contracts/interfaces/IFlatLaunchpeg.sol
+++ b/contracts/interfaces/IFlatLaunchpeg.sol
@@ -33,6 +33,7 @@ interface IFlatLaunchpeg is IBaseLaunchpeg {
     function initializePhases(
         uint256 _allowlistStartTime,
         uint256 _publicSaleStartTime,
+        uint256 _publicSaleEndTime,
         uint256 _allowlistPrice,
         uint256 _salePrice
     ) external;

--- a/contracts/interfaces/IFlatLaunchpeg.sol
+++ b/contracts/interfaces/IFlatLaunchpeg.sol
@@ -38,6 +38,8 @@ interface IFlatLaunchpeg is IBaseLaunchpeg {
         uint256 _salePrice
     ) external;
 
+    function setAllowlistStartTime(uint256 _allowlistStartTime) external;
+
     function allowlistMint(uint256 _quantity) external payable;
 
     function publicSaleMint(uint256 _quantity) external payable;

--- a/contracts/interfaces/ILaunchpeg.sol
+++ b/contracts/interfaces/ILaunchpeg.sol
@@ -56,6 +56,10 @@ interface ILaunchpeg is IBaseLaunchpeg {
         uint256 _publicSaleDiscountPercent
     ) external;
 
+    function setAuctionSaleStartTime(uint256 _auctionSaleStartTime) external;
+
+    function setAllowlistStartTime(uint256 _allowlistStartTime) external;
+
     function auctionMint(uint256 _quantity) external payable;
 
     function allowlistMint(uint256 _quantity) external payable;

--- a/contracts/interfaces/ILaunchpeg.sol
+++ b/contracts/interfaces/ILaunchpeg.sol
@@ -52,6 +52,7 @@ interface ILaunchpeg is IBaseLaunchpeg {
         uint256 _allowlistStartTime,
         uint256 _allowlistDiscountPercent,
         uint256 _publicSaleStartTime,
+        uint256 _publicSaleEndTime,
         uint256 _publicSaleDiscountPercent
     ) external;
 

--- a/test/FlatLaunchpeg.test.ts
+++ b/test/FlatLaunchpeg.test.ts
@@ -86,6 +86,14 @@ describe('FlatLaunchpeg', () => {
       )
     })
 
+    it('Public sale end time must be after public sale start time', async () => {
+      config.publicSaleEndTime = config.publicSaleStartTime.sub(duration.minutes(20))
+
+      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)).to.be.revertedWith(
+        'Launchpeg__PublicSaleEndBeforePublicSaleStart()'
+      )
+    })
+
     it('Allowlist price should be lower than Public sale', async () => {
       config.flatAllowlistSalePrice = config.flatAllowlistSalePrice.mul(10)
       await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)).to.be.revertedWith(
@@ -184,6 +192,12 @@ describe('FlatLaunchpeg', () => {
 
     it('Mint reverts during allowlist phase', async () => {
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
+
+      await expect(flatLaunchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
+    })
+
+    it('Mint reverts when public sale has ended', async () => {
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Ended)
 
       await expect(flatLaunchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
     })

--- a/test/Launchpeg.test.ts
+++ b/test/Launchpeg.test.ts
@@ -499,10 +499,9 @@ describe('Launchpeg', () => {
 
   describe('Project owner mint', () => {
     it('Mint up to max limit', async () => {
-      await expect(launchpeg.connect(projectOwner).devMint(config.amountForDevs - 1)).to.be.revertedWith(
-        'Launchpeg__CanOnlyMintMultipleOfMaxBatchSize()'
-      )
-      await launchpeg.connect(projectOwner).devMint(config.amountForDevs)
+      // mint amount that is not a multiple of max batch size
+      await launchpeg.connect(projectOwner).devMint(config.amountForDevs - 1)
+      await launchpeg.connect(projectOwner).devMint(1)
       await expect(launchpeg.connect(projectOwner).devMint(1)).to.be.revertedWith('Launchpeg__MaxSupplyForDevReached()')
       expect(await launchpeg.balanceOf(projectOwner.address)).to.eq(config.amountForDevs)
     })

--- a/test/Launchpeg.test.ts
+++ b/test/Launchpeg.test.ts
@@ -142,6 +142,7 @@ describe('Launchpeg', () => {
             config.allowlistStartTime,
             config.allowlistDiscount,
             config.publicSaleStartTime,
+            config.publicSaleEndTime,
             config.publicSaleDiscount
           )
       ).to.be.revertedWith('Ownable: caller is not the owner')
@@ -184,6 +185,14 @@ describe('Launchpeg', () => {
 
       await expect(initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)).to.be.revertedWith(
         'Launchpeg__PublicSaleBeforeAllowlist()'
+      )
+    })
+
+    it('Public sale end time must be after public sale start time', async () => {
+      config.publicSaleEndTime = config.publicSaleStartTime.sub(duration.minutes(60))
+
+      await expect(initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)).to.be.revertedWith(
+        'Launchpeg__PublicSaleEndBeforePublicSaleStart()'
       )
     })
 
@@ -433,6 +442,12 @@ describe('Launchpeg', () => {
 
     it('Mint reverts during allowlist phase', async () => {
       await initializePhasesLaunchpeg(launchpeg, config, Phase.Allowlist)
+
+      await expect(launchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
+    })
+
+    it('Mint reverts when public sale has ended', async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Ended)
 
       await expect(launchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
     })

--- a/test/Launchpeg.test.ts
+++ b/test/Launchpeg.test.ts
@@ -242,6 +242,27 @@ describe('Launchpeg', () => {
       ).to.be.revertedWith('Launchpeg__InvalidRevealDates()')
     })
 
+    it('Reverts when setting auction sale start time before phases are initialized', async () => {
+      const newAuctionSaleStartTime = config.auctionStartTime.sub(duration.minutes(30))
+      await expect(launchpeg.setAuctionSaleStartTime(newAuctionSaleStartTime)).to.be.revertedWith(
+        'Launchpeg__NotInitialized()'
+      )
+    })
+
+    it('Reverts when setting allowlist start time before phases are initialized', async () => {
+      const newAllowlistStartTime = config.allowlistStartTime.sub(duration.minutes(30))
+      await expect(launchpeg.setAllowlistStartTime(newAllowlistStartTime)).to.be.revertedWith(
+        'Launchpeg__NotInitialized()'
+      )
+    })
+
+    it('Reverts when setting public sale start time before phases are initialized', async () => {
+      const newPublicSaleStartTime = config.publicSaleStartTime.sub(duration.minutes(30))
+      await expect(launchpeg.setPublicSaleStartTime(newPublicSaleStartTime)).to.be.revertedWith(
+        'Launchpeg__NotInitialized()'
+      )
+    })
+
     it('Reverts when setting public sale end time before phases are initialized', async () => {
       const newPublicSaleEndTime = config.publicSaleEndTime.sub(duration.minutes(30))
       await expect(launchpeg.setPublicSaleEndTime(newPublicSaleEndTime)).to.be.revertedWith(
@@ -361,6 +382,60 @@ describe('Launchpeg', () => {
       expect(await launchpeg.balanceOf(bob.address)).to.eq(1)
     })
 
+    it('Owner can set auction sale start time', async () => {
+      let invalidAuctionSaleStartTime = BigNumber.from(0)
+      const newAuctionSaleStartTime = config.auctionStartTime.add(duration.minutes(30))
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
+      await expect(launchpeg.connect(projectOwner).setAuctionSaleStartTime(newAuctionSaleStartTime)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+      await expect(launchpeg.setAuctionSaleStartTime(invalidAuctionSaleStartTime)).to.be.revertedWith(
+        'Launchpeg__InvalidStartTime()'
+      )
+      invalidAuctionSaleStartTime = config.allowlistStartTime.add(duration.minutes(30))
+      await expect(launchpeg.setAuctionSaleStartTime(invalidAuctionSaleStartTime)).to.be.revertedWith(
+        'Launchpeg__AllowlistBeforeAuction()'
+      )
+      await launchpeg.setAuctionSaleStartTime(newAuctionSaleStartTime)
+      expect(await launchpeg.auctionSaleStartTime()).to.eq(newAuctionSaleStartTime)
+    })
+
+    it('Owner can set allowlist start time', async () => {
+      let invalidAllowlistStartTime = config.auctionStartTime.sub(duration.minutes(30))
+      const newAllowlistStartTime = config.allowlistStartTime.sub(duration.minutes(30))
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
+      await expect(launchpeg.connect(projectOwner).setAllowlistStartTime(newAllowlistStartTime)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+      await expect(launchpeg.setAllowlistStartTime(invalidAllowlistStartTime)).to.be.revertedWith(
+        'Launchpeg__AllowlistBeforeAuction()'
+      )
+      invalidAllowlistStartTime = config.publicSaleStartTime.add(duration.minutes(30))
+      await expect(launchpeg.setAllowlistStartTime(invalidAllowlistStartTime)).to.be.revertedWith(
+        'Launchpeg__PublicSaleBeforeAllowlist()'
+      )
+      await launchpeg.setAllowlistStartTime(newAllowlistStartTime)
+      expect(await launchpeg.allowlistStartTime()).to.eq(newAllowlistStartTime)
+    })
+
+    it('Owner can set public sale start time', async () => {
+      let invalidPublicSaleStartTime = config.allowlistStartTime.sub(duration.minutes(30))
+      const newPublicSaleStartTime = config.publicSaleStartTime.sub(duration.minutes(30))
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
+      await expect(launchpeg.connect(projectOwner).setPublicSaleStartTime(newPublicSaleStartTime)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+      await expect(launchpeg.setPublicSaleStartTime(invalidPublicSaleStartTime)).to.be.revertedWith(
+        'Launchpeg__PublicSaleBeforeAllowlist()'
+      )
+      invalidPublicSaleStartTime = config.publicSaleEndTime.add(duration.minutes(30))
+      await expect(launchpeg.setPublicSaleStartTime(invalidPublicSaleStartTime)).to.be.revertedWith(
+        'Launchpeg__PublicSaleEndBeforePublicSaleStart()'
+      )
+      await launchpeg.setPublicSaleStartTime(newPublicSaleStartTime)
+      expect(await launchpeg.publicSaleStartTime()).to.eq(newPublicSaleStartTime)
+    })
+
     it('Owner can set public sale end time', async () => {
       const invalidPublicSaleEndTime = config.publicSaleStartTime.sub(duration.minutes(30))
       const newPublicSaleEndTime = config.publicSaleEndTime.sub(duration.minutes(30))
@@ -442,6 +517,13 @@ describe('Launchpeg', () => {
       expect(await launchpeg.getAllowlistPrice()).to.eq(ethers.utils.parseUnits('0.9', 18))
     })
 
+    it('Owner can set public sale start time', async () => {
+      const newPublicSaleStartTime = config.publicSaleStartTime.sub(duration.minutes(30))
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Allowlist)
+      await launchpeg.setPublicSaleStartTime(newPublicSaleStartTime)
+      expect(await launchpeg.publicSaleStartTime()).to.eq(newPublicSaleStartTime)
+    })
+
     it('Owner can set public sale end time', async () => {
       const newPublicSaleEndTime = config.publicSaleEndTime.sub(duration.minutes(30))
       await initializePhasesLaunchpeg(launchpeg, config, Phase.Allowlist)
@@ -492,6 +574,34 @@ describe('Launchpeg', () => {
       await expect(launchpeg.connect(alice).publicSaleMint(2)).to.be.revertedWith('Launchpeg__NotEnoughAVAX(0)')
     })
 
+    it('Mint reverts when maxSupply is reached', async () => {
+      config.collectionSize = 10
+      config.amountForAuction = 0
+      config.amountForDevs = 0
+      config.amountForAllowlist = 0
+      config.maxBatchSize = 10
+      config.batchRevealSize = 10
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.PublicSale)
+
+      let quantity = 5
+      const price = config.flatPublicSalePrice
+      await launchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
+
+      quantity = 6
+      await expect(launchpeg.connect(alice).publicSaleMint(quantity)).to.be.revertedWith(
+        'Launchpeg__MaxSupplyReached()'
+      )
+
+      quantity = 5
+      await launchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
+
+      quantity = 1
+      await expect(launchpeg.connect(alice).publicSaleMint(quantity)).to.be.revertedWith(
+        'Launchpeg__WrongPhase()'
+      )
+    })
+
     it('Mint reverts when the user already minted max amount', async () => {
       await initializePhasesLaunchpeg(launchpeg, config, Phase.PublicSale)
 
@@ -539,19 +649,19 @@ describe('Launchpeg', () => {
       )
     })
 
-    it('Reverts when setting public sale end time', async () => {
+    it('Owner can set public sale end time', async () => {
       const newPublicSaleEndTime = config.publicSaleEndTime.sub(duration.minutes(30))
       await initializePhasesLaunchpeg(launchpeg, config, Phase.PublicSale)
-      await expect(launchpeg.setPublicSaleEndTime(newPublicSaleEndTime)).to.be.revertedWith(
-        'Launchpeg__WrongPhase()'
-      )
+      await launchpeg.setPublicSaleEndTime(newPublicSaleEndTime)
+      expect(await launchpeg.publicSaleEndTime()).to.eq(newPublicSaleEndTime)
     })
   })
 
   describe('Project owner mint', () => {
     it('Mint up to max limit', async () => {
       // mint amount that is not a multiple of max batch size
-      await launchpeg.connect(projectOwner).devMint(config.amountForDevs - 1)
+      await launchpeg.connect(projectOwner).devMint(config.maxBatchSize)
+      await launchpeg.connect(projectOwner).devMint(config.amountForDevs - config.maxBatchSize - 1)
       await launchpeg.connect(projectOwner).devMint(1)
       await expect(launchpeg.connect(projectOwner).devMint(1)).to.be.revertedWith('Launchpeg__MaxSupplyForDevReached()')
       expect(await launchpeg.balanceOf(projectOwner.address)).to.eq(config.amountForDevs)

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -6,6 +6,7 @@ export interface LaunchpegConfig {
   auctionStartTime: BigNumber
   allowlistStartTime: BigNumber
   publicSaleStartTime: BigNumber
+  publicSaleEndTime: BigNumber
   maxBatchSize: number
   collectionSize: number
   amountForAuction: number
@@ -28,6 +29,7 @@ export interface LaunchpegConfig {
 const AUCTION_START_OFFSET = 10
 const ALLOWLIST_START_OFFSET = 100
 const PUBLIC_SALE_START_OFFSET = 200
+const PUBLIC_SALE_END_OFFSET = 300
 const REVEAL_START_OFFSET = 400
 const REVEAL_INTERVAL = 50
 
@@ -37,6 +39,7 @@ export const getDefaultLaunchpegConfig = async (): Promise<LaunchpegConfig> => {
     auctionStartTime,
     allowlistStartTime: auctionStartTime.add(duration.minutes(ALLOWLIST_START_OFFSET)),
     publicSaleStartTime: auctionStartTime.add(duration.minutes(PUBLIC_SALE_START_OFFSET)),
+    publicSaleEndTime: auctionStartTime.add(duration.minutes(PUBLIC_SALE_END_OFFSET)),
     maxBatchSize: 5,
     collectionSize: 10000,
     amountForAuction: 8000,
@@ -63,6 +66,7 @@ export enum Phase {
   Allowlist,
   PublicSale,
   Reveal,
+  Ended
 }
 
 export const initializePhasesLaunchpeg = async (launchpeg: Contract, config: LaunchpegConfig, currentPhase: Phase) => {
@@ -74,6 +78,7 @@ export const initializePhasesLaunchpeg = async (launchpeg: Contract, config: Lau
     config.allowlistStartTime,
     config.allowlistDiscount,
     config.publicSaleStartTime,
+    config.publicSaleEndTime,
     config.publicSaleDiscount
   )
   await launchpeg.setUnrevealedURI(config.unrevealedTokenURI)
@@ -89,6 +94,7 @@ export const initializePhasesFlatLaunchpeg = async (
   await flatLaunchpeg.initializePhases(
     config.allowlistStartTime,
     config.publicSaleStartTime,
+    config.publicSaleEndTime,
     config.flatAllowlistSalePrice,
     config.flatPublicSalePrice
   )
@@ -109,6 +115,9 @@ const advanceTimeAndBlockToPhase = async (phase: Phase) => {
       break
     case Phase.PublicSale:
       await advanceTimeAndBlock(duration.minutes(PUBLIC_SALE_START_OFFSET + AUCTION_START_OFFSET))
+      break
+    case Phase.Ended:
+      await advanceTimeAndBlock(duration.minutes(PUBLIC_SALE_END_OFFSET + AUCTION_START_OFFSET))
       break
     case Phase.Reveal:
       await advanceTimeAndBlock(duration.minutes(REVEAL_START_OFFSET + AUCTION_START_OFFSET))


### PR DESCRIPTION
This PR:
- Removes the restriction that dev mint amount must be a multiple of `maxBatchSize`
- Adds a `publicSaleEndTime` variable to specify the end time for the public sale phase
- Allows the owner (not project owner) to update the `publicSaleEndTime` variable after phases are initialized

Subsequent PRs will:
- Allow the owner to update other time variables (e.g. `publicSaleStartTime`, etc.)
- Allow mint to be paused
- Implement a pre-mint feature