### PR TITLE
allow batch reveal configuration to be updated

### DIFF
--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -199,7 +199,10 @@ abstract contract BaseLaunchpeg is
             revert Launchpeg__InvalidProjectOwner();
         }
 
-        if (_amountForDevs + _amountForAllowlist > _collectionSize) {
+        if (
+            _collectionSize == 0 ||
+            _amountForDevs + _amountForAllowlist > _collectionSize
+        ) {
             revert Launchpeg__LargerCollectionSizeNeeded();
         }
 
@@ -565,7 +568,7 @@ abstract contract BaseLaunchpeg is
         override(ERC721AUpgradeable, IERC721MetadataUpgradeable)
         returns (string memory)
     {
-        if (!isBatchReveal()) {
+        if (isBatchRevealInitialized() && !isBatchRevealEnabled()) {
             return string(abi.encodePacked(baseURI, _id.toString()));
         } else if (_id >= lastTokenRevealed) {
             return unrevealedURI;

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -167,9 +167,6 @@ abstract contract BaseLaunchpeg is
     /// @param _collectionSize The collection size (e.g 10000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
     /// @param _amountForAllowlist Amount of NFTs available for the allowlist mint (e.g 1000)
-    /// @param _batchRevealSize Size of the batch reveal
-    /// @param _revealStartTime Batch reveal start time
-    /// @param _revealInterval Batch reveal interval
     function initializeBaseLaunchpeg(
         string memory _name,
         string memory _symbol,
@@ -178,22 +175,12 @@ abstract contract BaseLaunchpeg is
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _amountForAllowlist,
-        uint256 _batchRevealSize,
-        uint256 _revealStartTime,
-        uint256 _revealInterval
+        uint256 _amountForAllowlist
     ) internal onlyInitializing {
         __Ownable_init();
         __ReentrancyGuard_init();
         __ERC2981_init();
-
         __ERC721A_init(_name, _symbol);
-        initializeBatchReveal(
-            _batchRevealSize,
-            _collectionSize,
-            _revealStartTime,
-            _revealInterval
-        );
 
         if (_projectOwner == address(0)) {
             revert Launchpeg__InvalidProjectOwner();
@@ -454,7 +441,7 @@ abstract contract BaseLaunchpeg is
     /// batch reveal has been initialized and before a batch has
     /// been revealed.
     /// @dev Only callable by owner
-    /// @param _revealStartTime New batch reveal start time
+    /// @param _revealStartTime New batch reveal start time in seconds
     function setRevealStartTime(uint256 _revealStartTime)
         external
         override
@@ -467,7 +454,7 @@ abstract contract BaseLaunchpeg is
     /// batch reveal has been initialized and before a batch has
     /// been revealed.
     /// @dev Only callable by owner
-    /// @param _revealInterval New batch reveal interval
+    /// @param _revealInterval New batch reveal interval in seconds
     function setRevealInterval(uint256 _revealInterval)
         external
         override

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -100,13 +100,6 @@ abstract contract BatchReveal is
     /// @param revealInterval New reveal interval
     event RevealIntervalSet(uint256 revealInterval);
 
-    modifier initialized() {
-        if (!isBatchRevealInitialized()) {
-            revert Launchpeg__BatchRevealNotInitialized();
-        }
-        _;
-    }
-
     modifier revealNotStarted() {
         if (lastTokenRevealed != 0) {
             revert Launchpeg__BatchRevealStarted();
@@ -163,7 +156,6 @@ abstract contract BatchReveal is
     /// @param _revealBatchSize New reveal batch size
     function _setRevealBatchSize(uint256 _revealBatchSize)
         internal
-        initialized
         revealNotStarted
     {
         if (_revealBatchSize == 0) {
@@ -187,7 +179,6 @@ abstract contract BatchReveal is
     /// @param _revealStartTime New batch reveal start time
     function _setRevealStartTime(uint256 _revealStartTime)
         internal
-        initialized
         revealNotStarted
     {
         // probably a mistake if the reveal is more than 100 days in the future
@@ -204,7 +195,6 @@ abstract contract BatchReveal is
     /// @param _revealInterval New batch reveal interval
     function _setRevealInterval(uint256 _revealInterval)
         internal
-        initialized
         revealNotStarted
     {
         // probably a mistake if reveal interval is longer than 10 days
@@ -398,7 +388,11 @@ abstract contract BatchReveal is
     /// @dev If using VRF, the reveal happens on the coordinator callback call
     /// @param _totalSupply Number of token already minted
     /// @return isRevealed Returns false if it is not possible to reveal the next batch
-    function _revealNextBatch(uint256 _totalSupply) internal returns (bool) {
+    function _revealNextBatch(uint256 _totalSupply)
+        internal
+        batchRevealEnabled
+        returns (bool)
+    {
         uint256 batchNumber;
         bool canReveal;
         (canReveal, batchNumber) = _hasBatchToReveal(_totalSupply);

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -100,6 +100,13 @@ abstract contract BatchReveal is
     /// @param revealInterval New reveal interval
     event RevealIntervalSet(uint256 revealInterval);
 
+    modifier batchRevealInitialized() {
+        if (!isBatchRevealInitialized()) {
+            revert Launchpeg__BatchRevealNotInitialized();
+        }
+        _;
+    }
+
     modifier revealNotStarted() {
         if (lastTokenRevealed != 0) {
             revert Launchpeg__BatchRevealStarted();
@@ -139,6 +146,7 @@ abstract contract BatchReveal is
     /// @param _revealBatchSize New reveal batch size
     function _setRevealBatchSize(uint256 _revealBatchSize)
         internal
+        batchRevealInitialized
         revealNotStarted
     {
         if (_revealBatchSize == 0) {
@@ -162,6 +170,7 @@ abstract contract BatchReveal is
     /// @param _revealStartTime New batch reveal start time in seconds
     function _setRevealStartTime(uint256 _revealStartTime)
         internal
+        batchRevealInitialized
         revealNotStarted
     {
         // probably a mistake if the reveal is more than 100 days in the future
@@ -178,6 +187,7 @@ abstract contract BatchReveal is
     /// @param _revealInterval New batch reveal interval in seconds
     function _setRevealInterval(uint256 _revealInterval)
         internal
+        batchRevealInitialized
         revealNotStarted
     {
         // probably a mistake if reveal interval is longer than 10 days
@@ -441,6 +451,9 @@ abstract contract BatchReveal is
     }
 
     /// @dev Determines if batch reveal is initialized.
+    /// Since the collection size is only set on intializeBatchReveal()
+    /// and the collection size cannot be 0, we assume a 0 value means
+    /// the batch reveal configuration has not been initialized.
     function isBatchRevealInitialized() internal view returns (bool) {
         return collectionSize != 0;
     }

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -189,7 +189,6 @@ abstract contract BatchReveal is
         if (_revealStartTime > block.timestamp + 8_640_000) {
             revert Launchpeg__InvalidRevealDates();
         }
-        // TODO: can reveal start time be before current block time?
         revealStartTime = _revealStartTime;
         emit RevealStartTimeSet(_revealStartTime);
     }
@@ -197,7 +196,7 @@ abstract contract BatchReveal is
     /// @notice Set the batch reveal interval. Can only be set after
     /// batch reveal has been initialized and before a batch has
     /// been revealed.
-    /// @param _revealInterval New batch reveal batch size
+    /// @param _revealInterval New batch reveal interval
     function _setRevealInterval(uint256 _revealInterval)
         internal
         initialized
@@ -463,6 +462,8 @@ abstract contract BatchReveal is
     }
 
     /// @dev Determines if batch reveal is needed.
+    /// We assume batch reveal is needed if the configuration has
+    /// not been initialized or if revealBatchSize is not 0.
     function isBatchReveal() internal view returns (bool) {
         return !isInitialized() || revealBatchSize != 0;
     }

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.4;
 
 error LaunchpegFactory__InvalidImplementation();
-error Launchpeg__BatchRevealNotInitialized();
 error Launchpeg__BatchRevealStarted();
 error Launchpeg__CanNotMintThisMany();
 error Launchpeg__EndPriceGreaterThanStartPrice();

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.4;
 
 error LaunchpegFactory__InvalidImplementation();
+error Launchpeg__BatchRevealNotInitialized();
+error Launchpeg__BatchRevealStarted();
 error Launchpeg__CanNotMintThisMany();
 error Launchpeg__EndPriceGreaterThanStartPrice();
 error Launchpeg__HasBeenForceRevealed();

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 error LaunchpegFactory__InvalidImplementation();
+error Launchpeg__BatchRevealNotInitialized();
 error Launchpeg__BatchRevealStarted();
 error Launchpeg__CanNotMintThisMany();
 error Launchpeg__EndPriceGreaterThanStartPrice();

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -28,10 +28,7 @@ contract LaunchpegFactory is
         uint256 collectionSize,
         uint256 amountForAuction,
         uint256 amountForAllowlist,
-        uint256 amountForDevs,
-        uint256 batchRevealSize,
-        uint256 revealStartTime,
-        uint256 revealInterval
+        uint256 amountForDevs
     );
 
     event FlatLaunchpegCreated(
@@ -43,10 +40,7 @@ contract LaunchpegFactory is
         uint256 maxBatchSize,
         uint256 collectionSize,
         uint256 amountForDevs,
-        uint256 amountForAllowlist,
-        uint256 batchRevealSize,
-        uint256 revealStartTime,
-        uint256 revealInterval
+        uint256 amountForAllowlist
     );
 
     event SetLaunchpegImplementation(address indexed launchpegImplementation);
@@ -127,9 +121,6 @@ contract LaunchpegFactory is
     /// @param _amountForAuction Amount of NFTs available for the auction (e.g 8000)
     /// @param _amountForAllowlist Amount of NFTs available for the allowlist mint (e.g 1000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
-    /// @param _batchRevealData Contains batch reveal informations :
-    ///  Size of the batch reveal, start of the token URIs reveal in seconds
-    /// and interval between two batch reveals in seconds
     /// @return launchpeg New Launchpeg address
     function createLaunchpeg(
         string memory _name,
@@ -140,8 +131,7 @@ contract LaunchpegFactory is
         uint256 _collectionSize,
         uint256 _amountForAuction,
         uint256 _amountForAllowlist,
-        uint256 _amountForDevs,
-        BatchReveal calldata _batchRevealData
+        uint256 _amountForDevs
     ) external override onlyOwner returns (address) {
         address launchpeg = Clones.clone(launchpegImplementation);
 
@@ -157,10 +147,7 @@ contract LaunchpegFactory is
             _collectionSize,
             _amountForAuction,
             _amountForAllowlist,
-            _amountForDevs,
-            _batchRevealData.batchRevealSize,
-            _batchRevealData.revealStartTime,
-            _batchRevealData.revealInterval
+            _amountForDevs
         );
 
         IBaseLaunchpeg(launchpeg).initializeJoeFee(
@@ -180,10 +167,7 @@ contract LaunchpegFactory is
             _collectionSize,
             _amountForAuction,
             _amountForAllowlist,
-            _amountForDevs,
-            _batchRevealData.batchRevealSize,
-            _batchRevealData.revealStartTime,
-            _batchRevealData.revealInterval
+            _amountForDevs
         );
 
         return launchpeg;
@@ -198,9 +182,6 @@ contract LaunchpegFactory is
     /// @param _collectionSize The collection size (e.g 10000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
     /// @param _amountForAllowlist Amount of NFTs available for the allowlist mint (e.g 1000)
-    /// @param _batchRevealData Contains batch reveal informations :
-    ///  Size of the batch reveal, start of the token URIs reveal in seconds
-    /// and interval between two batch reveals in seconds
     /// @return flatLaunchpeg New FlatLaunchpeg address
     function createFlatLaunchpeg(
         string memory _name,
@@ -210,8 +191,7 @@ contract LaunchpegFactory is
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _amountForAllowlist,
-        BatchReveal calldata _batchRevealData
+        uint256 _amountForAllowlist
     ) external override onlyOwner returns (address) {
         address flatLaunchpeg = Clones.clone(flatLaunchpegImplementation);
 
@@ -226,10 +206,7 @@ contract LaunchpegFactory is
             _maxBatchSize,
             _collectionSize,
             _amountForDevs,
-            _amountForAllowlist,
-            _batchRevealData.batchRevealSize,
-            _batchRevealData.revealStartTime,
-            _batchRevealData.revealInterval
+            _amountForAllowlist
         );
 
         IBaseLaunchpeg(flatLaunchpeg).initializeJoeFee(
@@ -248,10 +225,7 @@ contract LaunchpegFactory is
             _maxBatchSize,
             _collectionSize,
             _amountForDevs,
-            _amountForAllowlist,
-            _batchRevealData.batchRevealSize,
-            _batchRevealData.revealStartTime,
-            _batchRevealData.revealInterval
+            _amountForAllowlist
         );
 
         return flatLaunchpeg;

--- a/contracts/interfaces/IBaseLaunchpeg.sol
+++ b/contracts/interfaces/IBaseLaunchpeg.sol
@@ -79,6 +79,12 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
 
     function setPublicSaleEndTime(uint256 _publicSaleEndTime) external;
 
+    function setRevealBatchSize(uint256 _revealBatchSize) external;
+
+    function setRevealStartTime(uint256 _revealStartTime) external;
+
+    function setRevealInterval(uint256 _revealInterval) external;
+
     function devMint(uint256 quantity) external;
 
     function withdrawAVAX(address to) external;

--- a/contracts/interfaces/IFlatLaunchpeg.sol
+++ b/contracts/interfaces/IFlatLaunchpeg.sol
@@ -24,10 +24,7 @@ interface IFlatLaunchpeg is IBaseLaunchpeg {
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _amountForAllowlist,
-        uint256 _batchRevealSize,
-        uint256 _revealStartTime,
-        uint256 _revealInterval
+        uint256 _amountForAllowlist
     ) external;
 
     function initializePhases(
@@ -35,7 +32,10 @@ interface IFlatLaunchpeg is IBaseLaunchpeg {
         uint256 _publicSaleStartTime,
         uint256 _publicSaleEndTime,
         uint256 _allowlistPrice,
-        uint256 _salePrice
+        uint256 _salePrice,
+        uint256 _batchRevealSize,
+        uint256 _revealStartTime,
+        uint256 _revealInterval
     ) external;
 
     function setAllowlistStartTime(uint256 _allowlistStartTime) external;

--- a/contracts/interfaces/ILaunchpeg.sol
+++ b/contracts/interfaces/ILaunchpeg.sol
@@ -38,10 +38,7 @@ interface ILaunchpeg is IBaseLaunchpeg {
         uint256 _collectionSize,
         uint256 _amountForAuction,
         uint256 _amountForAllowlist,
-        uint256 _amountForDevs,
-        uint256 _batchRevealSize,
-        uint256 _revealStartTime,
-        uint256 _revealInterval
+        uint256 _amountForDevs
     ) external;
 
     function initializePhases(
@@ -53,7 +50,10 @@ interface ILaunchpeg is IBaseLaunchpeg {
         uint256 _allowlistDiscountPercent,
         uint256 _publicSaleStartTime,
         uint256 _publicSaleEndTime,
-        uint256 _publicSaleDiscountPercent
+        uint256 _publicSaleDiscountPercent,
+        uint256 _batchRevealSize,
+        uint256 _revealStartTime,
+        uint256 _revealInterval
     ) external;
 
     function setAuctionSaleStartTime(uint256 _auctionSaleStartTime) external;

--- a/contracts/interfaces/ILaunchpegFactory.sol
+++ b/contracts/interfaces/ILaunchpegFactory.sol
@@ -5,12 +5,6 @@ pragma solidity ^0.8.4;
 /// @author Trader Joe
 /// @notice Defines the basic interface of LaunchpegFactory
 interface ILaunchpegFactory {
-    struct BatchReveal {
-        uint256 batchRevealSize;
-        uint256 revealStartTime;
-        uint256 revealInterval;
-    }
-
     function launchpegImplementation() external view returns (address);
 
     function flatLaunchpegImplementation() external view returns (address);
@@ -43,8 +37,7 @@ interface ILaunchpegFactory {
         uint256 _collectionSize,
         uint256 _amountForAuction,
         uint256 _amountForAllowlist,
-        uint256 _amountForDevs,
-        BatchReveal calldata _batchRevealData
+        uint256 _amountForDevs
     ) external returns (address);
 
     function createFlatLaunchpeg(
@@ -55,8 +48,7 @@ interface ILaunchpegFactory {
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _amountForAllowlist,
-        BatchReveal calldata _batchRevealData
+        uint256 _amountForAllowlist
     ) external returns (address);
 
     function setLaunchpegImplementation(address _launchpegImplementation)

--- a/test/FlatLaunchpeg.test.ts
+++ b/test/FlatLaunchpeg.test.ts
@@ -63,6 +63,12 @@ describe('FlatLaunchpeg', () => {
   })
 
   describe('Initialization', () => {
+    it('Collection size cannot be 0', async () => {
+      config.collectionSize = 0
+      config.batchRevealSize = 0
+      await expect(deployFlatLaunchpeg()).to.be.revertedWith('Launchpeg__LargerCollectionSizeNeeded()')
+    })
+
     it('Phases can be updated', async () => {
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)
 
@@ -242,6 +248,48 @@ describe('FlatLaunchpeg', () => {
       )
       await flatLaunchpeg.setPublicSaleEndTime(newPublicSaleEndTime)
       expect(await flatLaunchpeg.publicSaleEndTime()).to.eq(newPublicSaleEndTime)
+    })
+
+    it('Owner can set reveal batch size', async () => {
+      const invalidRevealBatchSize = 101
+      const newRevealBatchSize = 100
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
+      await expect(flatLaunchpeg.connect(projectOwner).setRevealBatchSize(newRevealBatchSize)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+      await expect(flatLaunchpeg.setRevealBatchSize(invalidRevealBatchSize)).to.be.revertedWith(
+        'Launchpeg__InvalidBatchRevealSize()'
+      )
+      await flatLaunchpeg.setRevealBatchSize(newRevealBatchSize)
+      expect(await flatLaunchpeg.revealBatchSize()).to.eq(newRevealBatchSize)
+    })
+
+    it('Owner can set reveal start time', async () => {
+      const invalidRevealStartTime = config.batchRevealStart.add(duration.minutes(8_640_000))
+      const newRevealStartTime = config.batchRevealStart.add(duration.minutes(30))
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
+      await expect(flatLaunchpeg.connect(projectOwner).setRevealStartTime(newRevealStartTime)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+      await expect(flatLaunchpeg.setRevealStartTime(invalidRevealStartTime)).to.be.revertedWith(
+        'Launchpeg__InvalidRevealDates()'
+      )
+      await flatLaunchpeg.setRevealStartTime(newRevealStartTime)
+      expect(await flatLaunchpeg.revealStartTime()).to.eq(newRevealStartTime)
+    })
+
+    it('Owner can set reveal interval', async () => {
+      const invalidRevealInterval = 864_001
+      const newRevealInterval = config.batchRevealInterval.add(10)
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
+      await expect(flatLaunchpeg.connect(projectOwner).setRevealInterval(newRevealInterval)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+      await expect(flatLaunchpeg.setRevealInterval(invalidRevealInterval)).to.be.revertedWith(
+        'Launchpeg__InvalidRevealDates()'
+      )
+      await flatLaunchpeg.setRevealInterval(newRevealInterval)
+      expect(await flatLaunchpeg.revealInterval()).to.eq(newRevealInterval)
     })
   })
 

--- a/test/FlatLaunchpeg.test.ts
+++ b/test/FlatLaunchpeg.test.ts
@@ -50,10 +50,7 @@ describe('FlatLaunchpeg', () => {
       config.maxBatchSize,
       config.collectionSize,
       config.amountForDevs,
-      config.amountForAllowlist,
-      config.batchRevealSize,
-      config.batchRevealStart,
-      config.batchRevealInterval
+      config.amountForAllowlist
     )
   }
 
@@ -63,7 +60,7 @@ describe('FlatLaunchpeg', () => {
   })
 
   describe('Initialization', () => {
-    it('Collection size cannot be 0', async () => {
+    it('Should not allow collection size to be 0', async () => {
       config.collectionSize = 0
       config.batchRevealSize = 0
       await expect(deployFlatLaunchpeg()).to.be.revertedWith('Launchpeg__LargerCollectionSizeNeeded()')
@@ -104,6 +101,33 @@ describe('FlatLaunchpeg', () => {
       config.flatAllowlistSalePrice = config.flatAllowlistSalePrice.mul(10)
       await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)).to.be.revertedWith(
         'Launchpeg__InvalidAllowlistPrice()'
+      )
+    })
+
+    it('Should allow 0 batch reveal size', async () => {
+      config.batchRevealSize = 0
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)
+      expect(await flatLaunchpeg.revealBatchSize()).to.eq(0)
+    })
+
+    it('Should not allow invalid reveal batch size', async () => {
+      config.batchRevealSize = config.batchRevealSize + 1
+      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)).to.be.revertedWith(
+        'Launchpeg__InvalidBatchRevealSize()'
+      )
+    })
+
+    it('Should not allow invalid reveal start time', async () => {
+      config.batchRevealStart = config.batchRevealStart.add(8_640_000)
+      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)).to.be.revertedWith(
+        'Launchpeg__InvalidRevealDates()'
+      )
+    })
+
+    it('Should not allow invalid reveal interval', async () => {
+      config.batchRevealInterval = config.batchRevealInterval.add(864_000)
+      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)).to.be.revertedWith(
+        'Launchpeg__InvalidRevealDates()'
       )
     })
 
@@ -222,9 +246,9 @@ describe('FlatLaunchpeg', () => {
       let invalidPublicSaleStartTime = config.allowlistStartTime.sub(duration.minutes(30))
       const newPublicSaleStartTime = config.publicSaleStartTime.sub(duration.minutes(30))
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(flatLaunchpeg.connect(projectOwner).setPublicSaleStartTime(newPublicSaleStartTime)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
+      await expect(
+        flatLaunchpeg.connect(projectOwner).setPublicSaleStartTime(newPublicSaleStartTime)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
       await expect(flatLaunchpeg.setPublicSaleStartTime(invalidPublicSaleStartTime)).to.be.revertedWith(
         'Launchpeg__PublicSaleBeforeAllowlist()'
       )
@@ -250,7 +274,7 @@ describe('FlatLaunchpeg', () => {
       expect(await flatLaunchpeg.publicSaleEndTime()).to.eq(newPublicSaleEndTime)
     })
 
-    it('Owner can set reveal batch size', async () => {
+    it('Should allow owner to set reveal batch size', async () => {
       const invalidRevealBatchSize = 101
       const newRevealBatchSize = 100
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
@@ -264,7 +288,7 @@ describe('FlatLaunchpeg', () => {
       expect(await flatLaunchpeg.revealBatchSize()).to.eq(newRevealBatchSize)
     })
 
-    it('Owner can set reveal start time', async () => {
+    it('Should allow owner to set reveal start time', async () => {
       const invalidRevealStartTime = config.batchRevealStart.add(duration.minutes(8_640_000))
       const newRevealStartTime = config.batchRevealStart.add(duration.minutes(30))
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
@@ -278,7 +302,7 @@ describe('FlatLaunchpeg', () => {
       expect(await flatLaunchpeg.revealStartTime()).to.eq(newRevealStartTime)
     })
 
-    it('Owner can set reveal interval', async () => {
+    it('Should allow owner to set reveal interval', async () => {
       const invalidRevealInterval = 864_001
       const newRevealInterval = config.batchRevealInterval.add(10)
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
@@ -353,9 +377,7 @@ describe('FlatLaunchpeg', () => {
       await flatLaunchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
 
       quantity = 1
-      await expect(flatLaunchpeg.connect(alice).publicSaleMint(quantity)).to.be.revertedWith(
-        'Launchpeg__WrongPhase()'
-      )
+      await expect(flatLaunchpeg.connect(alice).publicSaleMint(quantity)).to.be.revertedWith('Launchpeg__WrongPhase()')
     })
 
     it('Mint reverts when address minted maxBatchSize', async () => {

--- a/test/Launchpeg.test.ts
+++ b/test/Launchpeg.test.ts
@@ -204,6 +204,18 @@ describe('Launchpeg', () => {
       )
     })
 
+    it('Should not allow batch reveal config to be set prior to batch reveal initialization', async () => {
+      await expect(launchpeg.setRevealBatchSize(config.batchRevealSize)).to.be.revertedWith(
+        'Launchpeg__BatchRevealNotInitialized'
+      )
+      await expect(launchpeg.setRevealStartTime(config.batchRevealStart)).to.be.revertedWith(
+        'Launchpeg__BatchRevealNotInitialized'
+      )
+      await expect(launchpeg.setRevealInterval(config.batchRevealInterval)).to.be.revertedWith(
+        'Launchpeg__BatchRevealNotInitialized'
+      )
+    })
+
     it('Should allow 0 batch reveal size', async () => {
       config.batchRevealSize = 0
       await initializePhasesLaunchpeg(launchpeg, config, Phase.NotStarted)

--- a/test/LaunchpegFactory.test.ts
+++ b/test/LaunchpegFactory.test.ts
@@ -61,10 +61,7 @@ describe('LaunchpegFactory', () => {
       config.collectionSize,
       config.amountForAuction,
       config.amountForAllowlist,
-      config.amountForDevs,
-      config.batchRevealSize,
-      config.batchRevealStart,
-      config.batchRevealInterval
+      config.amountForDevs
     )
   }
 
@@ -79,10 +76,7 @@ describe('LaunchpegFactory', () => {
       config.maxBatchSize,
       config.collectionSize,
       config.amountForDevs,
-      config.amountForAllowlist,
-      config.batchRevealSize,
-      config.batchRevealStart,
-      config.batchRevealInterval
+      config.amountForAllowlist
     )
   }
 
@@ -157,8 +151,7 @@ describe('LaunchpegFactory', () => {
         config.collectionSize,
         config.amountForAuction,
         config.amountForAllowlist,
-        config.amountForDevs,
-        [config.batchRevealSize, config.batchRevealStart, config.batchRevealInterval]
+        config.amountForDevs
       )
 
       expect(await launchpegFactory.numLaunchpegs(0)).to.equal(1)
@@ -175,8 +168,7 @@ describe('LaunchpegFactory', () => {
         config.maxBatchSize,
         config.collectionSize,
         config.amountForDevs,
-        config.amountForAllowlist,
-        [config.batchRevealSize, config.batchRevealStart, config.batchRevealInterval]
+        config.amountForAllowlist
       )
 
       expect(await launchpegFactory.numLaunchpegs(1)).to.equal(1)
@@ -216,8 +208,7 @@ describe('LaunchpegFactory', () => {
         config.collectionSize,
         config.amountForAuction,
         config.amountForAllowlist,
-        config.amountForDevs,
-        [config.batchRevealSize, config.batchRevealStart, config.batchRevealInterval]
+        config.amountForDevs
       )
       const launchpeg0Address = await launchpegFactory.allLaunchpegs(0, 0)
       const launchpeg0 = await ethers.getContractAt('Launchpeg', launchpeg0Address)

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -66,7 +66,7 @@ export enum Phase {
   Allowlist,
   PublicSale,
   Reveal,
-  Ended
+  Ended,
 }
 
 export const initializePhasesLaunchpeg = async (launchpeg: Contract, config: LaunchpegConfig, currentPhase: Phase) => {
@@ -79,7 +79,10 @@ export const initializePhasesLaunchpeg = async (launchpeg: Contract, config: Lau
     config.allowlistDiscount,
     config.publicSaleStartTime,
     config.publicSaleEndTime,
-    config.publicSaleDiscount
+    config.publicSaleDiscount,
+    config.batchRevealSize,
+    config.batchRevealStart,
+    config.batchRevealInterval
   )
   await launchpeg.setUnrevealedURI(config.unrevealedTokenURI)
   await launchpeg.setBaseURI(config.baseTokenURI)
@@ -96,7 +99,10 @@ export const initializePhasesFlatLaunchpeg = async (
     config.publicSaleStartTime,
     config.publicSaleEndTime,
     config.flatAllowlistSalePrice,
-    config.flatPublicSalePrice
+    config.flatPublicSalePrice,
+    config.batchRevealSize,
+    config.batchRevealStart,
+    config.batchRevealInterval
   )
   await flatLaunchpeg.setUnrevealedURI(config.unrevealedTokenURI)
   await flatLaunchpeg.setBaseURI(config.baseTokenURI)


### PR DESCRIPTION
This PR:
* Adds setter methods to update the batch reveal configuration (e.g. reveal batch size, reveal start time, reveal interval)
* Adds logic to disable batch reveal if the reveal batch size is set to 0
* Initializes batch reveal when initializing phases instead of during contract creation