### PR TITLE
Refactor BatchReveal architecture

### DIFF
--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -493,4 +493,18 @@ abstract contract BaseLaunchpeg is
             }
         }
     }
+
+    /// @notice Reveals the next batch if the reveal conditions are met
+    function revealNextBatch() external override isEOA {
+        if (!batchReveal.revealNextBatch(totalSupply())) {
+            revert Launchpeg__RevealNextBatchNotAvailable();
+        }
+    }
+
+    /// @notice Tells you if a batch can be revealed
+    /// @return bool Whether reveal can be triggered or not
+    /// @return uint256 The number of the next batch that will be revealed
+    function hasBatchToReveal() external view override returns (bool, uint256) {
+        return batchReveal.hasBatchToReveal(totalSupply());
+    }
 }

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -506,6 +506,9 @@ abstract contract BaseLaunchpeg is
 
     /// @notice Reveals the next batch if the reveal conditions are met
     function revealNextBatch() external override isEOA {
+        if (address(batchReveal) == address(0)) {
+            revert Launchpeg__BatchRevealDisabled();
+        }
         if (!batchReveal.revealNextBatch(address(this), totalSupply())) {
             revert Launchpeg__RevealNextBatchNotAvailable();
         }
@@ -515,6 +518,9 @@ abstract contract BaseLaunchpeg is
     /// @return bool Whether reveal can be triggered or not
     /// @return uint256 The number of the next batch that will be revealed
     function hasBatchToReveal() external view override returns (bool, uint256) {
+        if (address(batchReveal) == address(0)) {
+            return (false, 0);
+        }
         return batchReveal.hasBatchToReveal(address(this), totalSupply());
     }
 }

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -475,12 +475,12 @@ abstract contract BaseLaunchpeg is
         emit DevMint(msg.sender, _quantity);
     }
 
-    /// @notice Withdraw AVAX to the contract owner
+    /// @notice Withdraw AVAX to the given recipient
     /// @param _to Recipient of the earned AVAX
     function withdrawAVAX(address _to)
         external
         override
-        onlyOwner
+        onlyOwnerOrRole(PROJECT_OWNER_ROLE)
         nonReentrant
     {
         uint256 amount = address(this).balance;

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -338,6 +338,9 @@ abstract contract BaseLaunchpeg is
 
     /// @notice Update batch reveal
     function setBatchReveal(address _batchReveal) external override onlyOwner {
+        if (IBatchReveal(_batchReveal).baseLaunchpeg() != address(this)) {
+            revert Launchpeg__InvalidBatchReveal();
+        }
         batchReveal = IBatchReveal(_batchReveal);
     }
 

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -84,6 +84,9 @@ abstract contract BaseLaunchpeg is
     /// @dev A timestamp greater than the public sale start
     uint256 public override publicSaleEndTime;
 
+    /// @notice Start time when funds can be withdrawn
+    uint256 public override withdrawAVAXStartTime;
+
     /// @dev Emitted on initializeJoeFee()
     /// @param feePercent The fees collected by Joepegs on the sale benefits
     /// @param feeCollector The address to which the fees on the sale will be sent
@@ -139,6 +142,10 @@ abstract contract BaseLaunchpeg is
     /// @dev Emitted on setPublicSaleEndTime()
     /// @param publicSaleEndTime New public sale end time
     event PublicSaleEndTimeSet(uint256 publicSaleEndTime);
+
+    /// @dev Emitted on setWithdrawAVAXStartTime()
+    /// @param withdrawAVAXStartTime New withdraw AVAX start time
+    event WithdrawAVAXStartTimeSet(uint256 withdrawAVAXStartTime);
 
     modifier isEOA() {
         if (tx.origin != msg.sender) {
@@ -449,6 +456,17 @@ abstract contract BaseLaunchpeg is
         _setRevealInterval(_revealInterval);
     }
 
+    /// @notice Set the withdraw AVAX start time.
+    /// @param _withdrawAVAXStartTime New public sale end time
+    function setWithdrawAVAXStartTime(uint256 _withdrawAVAXStartTime)
+        external
+        override
+        onlyOwner
+    {
+        withdrawAVAXStartTime = _withdrawAVAXStartTime;
+        emit WithdrawAVAXStartTimeSet(_withdrawAVAXStartTime);
+    }
+
     /// @notice Mint NFTs to the project owner
     /// @dev Can only mint up to `amountForDevs`
     /// @param _quantity Quantity of NFTs to mint
@@ -483,6 +501,10 @@ abstract contract BaseLaunchpeg is
         onlyOwnerOrRole(PROJECT_OWNER_ROLE)
         nonReentrant
     {
+        if (withdrawAVAXStartTime > block.timestamp) {
+            revert Launchpeg__WithdrawAVAXNotAvailable();
+        }
+
         uint256 amount = address(this).balance;
         uint256 fee;
         bool sent;

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -425,10 +425,7 @@ abstract contract BaseLaunchpeg is
         override(ERC721AUpgradeable, IERC721MetadataUpgradeable)
         returns (string memory)
     {
-        if (
-            batchReveal.isBatchRevealInitialized() &&
-            !batchReveal.isBatchRevealEnabled()
-        ) {
+        if (address(batchReveal) == address(0)) {
             return string(abi.encodePacked(baseURI, _id.toString()));
         } else if (_id >= batchReveal.lastTokenRevealed()) {
             return unrevealedURI;

--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -332,6 +332,9 @@ abstract contract BaseLaunchpeg is
         override
         onlyOwner
     {
+        if (_withdrawAVAXStartTime < block.timestamp) {
+            revert Launchpeg__InvalidStartTime();
+        }
         withdrawAVAXStartTime = _withdrawAVAXStartTime;
         emit WithdrawAVAXStartTimeSet(_withdrawAVAXStartTime);
     }
@@ -378,7 +381,10 @@ abstract contract BaseLaunchpeg is
         onlyOwnerOrRole(PROJECT_OWNER_ROLE)
         nonReentrant
     {
-        if (withdrawAVAXStartTime > block.timestamp) {
+        if (
+            withdrawAVAXStartTime > block.timestamp ||
+            withdrawAVAXStartTime == 0
+        ) {
             revert Launchpeg__WithdrawAVAXNotAvailable();
         }
 

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -137,8 +137,8 @@ contract BatchReveal is
         uint256 _revealStartTime,
         uint256 _revealInterval
     ) external override initializer {
-         __Ownable_init();
-         
+        __Ownable_init();
+
         if (
             (_revealBatchSize != 0 &&
                 (_collectionSize % _revealBatchSize != 0)) ||
@@ -451,9 +451,10 @@ contract BatchReveal is
     /// @param _totalSupply Number of token already minted
     /// @return hasToRevealInfo Returns a bool saying whether a reveal can be triggered or not
     /// and the number of the next batch that will be revealed
-    function _hasBatchToReveal(uint256 _totalSupply)
-        internal
+    function hasBatchToReveal(uint256 _totalSupply)
+        public
         view
+        override
         batchRevealEnabled
         returns (bool, uint256)
     {
@@ -478,14 +479,15 @@ contract BatchReveal is
     /// @dev If using VRF, the reveal happens on the coordinator callback call
     /// @param _totalSupply Number of token already minted
     /// @return isRevealed Returns false if it is not possible to reveal the next batch
-    function _revealNextBatch(uint256 _totalSupply)
-        internal
+    function revealNextBatch(uint256 _totalSupply)
+        external
+        override
         batchRevealEnabled
         returns (bool)
     {
         uint256 batchNumber;
         bool canReveal;
-        (canReveal, batchNumber) = _hasBatchToReveal(_totalSupply);
+        (canReveal, batchNumber) = hasBatchToReveal(_totalSupply);
 
         if (!canReveal) {
             return false;
@@ -531,7 +533,7 @@ contract BatchReveal is
     }
 
     /// @dev Force reveal, should be restricted to owner
-    function _forceReveal() internal batchRevealEnabled {
+    function forceReveal() external override onlyOwner batchRevealEnabled {
         uint256 batchNumber;
         unchecked {
             batchNumber = lastTokenRevealed / revealBatchSize;

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@chainlink/contracts/src/v0.8/interfaces/VRFCoordinatorV2Interface.sol";
 
 import "./chainlink/VRFConsumerBaseV2Upgradeable.sol";
@@ -13,10 +14,11 @@ import "./LaunchpegErrors.sol";
 
 /// @title BatchReveal
 /// @notice Implements a gas efficient way of revealing NFT URIs gradually
-abstract contract BatchReveal is
+contract BatchReveal is
     IBatchReveal,
     VRFConsumerBaseV2Upgradeable,
-    Initializable
+    Initializable,
+    OwnableUpgradeable
 {
     /// @dev Initialized on parent contract creation
     uint256 private collectionSize;
@@ -167,8 +169,10 @@ abstract contract BatchReveal is
     /// been revealed.
     /// @dev Set to 0 to disable batch reveal
     /// @param _revealBatchSize New reveal batch size
-    function _setRevealBatchSize(uint256 _revealBatchSize)
-        internal
+    function setRevealBatchSize(uint256 _revealBatchSize)
+        external
+        override
+        onlyOwner
         revealNotStarted
     {
         if (_revealBatchSize == 0) {
@@ -190,8 +194,10 @@ abstract contract BatchReveal is
     /// batch reveal has been initialized and before a batch has
     /// been revealed.
     /// @param _revealStartTime New batch reveal start time
-    function _setRevealStartTime(uint256 _revealStartTime)
-        internal
+    function setRevealStartTime(uint256 _revealStartTime)
+        external
+        override
+        onlyOwner
         revealNotStarted
     {
         // probably a mistake if the reveal is more than 100 days in the future
@@ -206,8 +212,10 @@ abstract contract BatchReveal is
     /// batch reveal has been initialized and before a batch has
     /// been revealed.
     /// @param _revealInterval New batch reveal interval
-    function _setRevealInterval(uint256 _revealInterval)
-        internal
+    function setRevealInterval(uint256 _revealInterval)
+        external
+        override
+        onlyOwner
         revealNotStarted
     {
         // probably a mistake if reveal interval is longer than 10 days
@@ -223,12 +231,12 @@ abstract contract BatchReveal is
     /// @param _keyHash Keyhash of the gas lane wanted
     /// @param _subscriptionId Chainlink subscription ID
     /// @param _callbackGasLimit Max gas used by the coordinator callback
-    function _setVRF(
+    function setVRF(
         address _vrfCoordinator,
         bytes32 _keyHash,
         uint64 _subscriptionId,
         uint32 _callbackGasLimit
-    ) internal {
+    ) external override onlyOwner {
         if (_vrfCoordinator == address(0)) {
             revert Launchpeg__InvalidCoordinator();
         }

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -342,6 +342,7 @@ contract BatchReveal is
     /// @param _start beginning of the array to be added
     /// @param _end end of the array to be added
     /// @param _lastIndex last position in the range array to consider
+    /// @param _intCollectionSize collection size
     /// @return newLastIndex new lastIndex to consider for the future range to be added
     function _addRange(
         Range[] memory _ranges,
@@ -631,10 +632,10 @@ contract BatchReveal is
     /// @dev Callback triggered by the VRF coordinator
     /// @param _randomWords Array of random numbers provided by the VRF coordinator
     function fulfillRandomWords(
-        uint256 requestId,
+        uint256 _requestId,
         uint256[] memory _randomWords
     ) internal override {
-        address baseLaunchpeg = vrfRequestIdToLaunchpeg[requestId];
+        address baseLaunchpeg = vrfRequestIdToLaunchpeg[_requestId];
 
         if (launchpegToHasBeenForceRevealed[baseLaunchpeg]) {
             revert Launchpeg__HasBeenForceRevealed();

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -1,7 +1,6 @@
 //SPDX-License-Identifier: CC0
 pragma solidity ^0.8.4;
 
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@chainlink/contracts/src/v0.8/interfaces/VRFCoordinatorV2Interface.sol";
 
@@ -17,7 +16,6 @@ import "./LaunchpegErrors.sol";
 contract BatchReveal is
     IBatchReveal,
     VRFConsumerBaseV2Upgradeable,
-    Initializable,
     OwnableUpgradeable
 {
     /// @dev Initialized on parent contract creation
@@ -138,7 +136,9 @@ contract BatchReveal is
         uint256 _collectionSize,
         uint256 _revealStartTime,
         uint256 _revealInterval
-    ) external override onlyInitializing {
+    ) external override initializer {
+         __Ownable_init();
+         
         if (
             (_revealBatchSize != 0 &&
                 (_collectionSize % _revealBatchSize != 0)) ||

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -131,12 +131,12 @@ abstract contract BatchReveal is
     /// @param _collectionSize Needs to be sent by child contract
     /// @param _revealStartTime Batch reveal start time
     /// @param _revealInterval Batch reveal interval
-    function initializeBatchReveal(
+    function initialize(
         uint256 _revealBatchSize,
         uint256 _collectionSize,
         uint256 _revealStartTime,
         uint256 _revealInterval
-    ) internal onlyInitializing {
+    ) external override onlyInitializing {
         if (
             (_revealBatchSize != 0 &&
                 (_collectionSize % _revealBatchSize != 0)) ||
@@ -366,8 +366,8 @@ abstract contract BatchReveal is
     /// @return uriId Revealed Token URI Id
     function getShuffledTokenId(uint256 _startId)
         external
-        override
         view
+        override
         returns (uint256)
     {
         uint256 batch = _startId / revealBatchSize;
@@ -537,12 +537,12 @@ abstract contract BatchReveal is
 
     /// @dev Determines if batch reveal is enabled.
     /// Batch reveal is enabled if revealBatchSize is not 0.
-    function isBatchRevealEnabled() public override view returns (bool) {
+    function isBatchRevealEnabled() public view override returns (bool) {
         return revealBatchSize != 0;
     }
 
     /// @dev Determines if batch reveal is initialized.
-    function isBatchRevealInitialized() public override view returns (bool) {
+    function isBatchRevealInitialized() public view override returns (bool) {
         return collectionSize != 0;
     }
 }

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -19,33 +19,22 @@ contract BatchReveal is
     VRFConsumerBaseV2Upgradeable,
     OwnableUpgradeable
 {
-    /// @notice Base launchpeg address
-    address public override baseLaunchpeg;
+    /// @notice Batch reveal configuration by launchpeg
+    mapping(address => BatchRevealConfig) public override launchpegToConfig;
 
-    /// @dev Initialized on parent contract creation
-    uint256 private collectionSize;
-    int128 private intCollectionSize;
+    /// @notice VRF request ids by launchpeg
+    mapping(uint256 => address) public vrfRequestIdToLaunchpeg;
 
-    /// @notice Size of the batch reveal
-    /// @dev Must divide collectionSize
-    uint256 public override revealBatchSize;
+    /// @notice Randomized seeds used to shuffle TokenURIs by launchpeg
+    mapping(address => mapping(uint256 => uint256))
+        public
+        override launchpegToBatchToSeed;
 
-    /// @notice Randomized seeds used to shuffle TokenURIs
-    mapping(uint256 => uint256) public override batchToSeed;
+    /// @notice Last token that has been revealed by launchpeg
+    mapping(address => uint256) public override launchpegToLastTokenReveal;
 
-    /// @notice Last token that has been revealed
-    uint256 public override lastTokenRevealed = 0;
-
-    /// @dev Size of the array that will store already taken URIs numbers
-    uint256 private _rangeLength;
-
-    /// @notice Timestamp for the start of the reveal process
-    /// @dev Can be set to zero for immediate reveal after token mint
-    uint256 public override revealStartTime;
-
-    /// @notice Time interval for gradual reveal
-    /// @dev Can be set to zero in order to reveal the collection all at once
-    uint256 public override revealInterval;
+    /// @dev Size of the array that will store already taken URIs numbers by launchpeg
+    mapping(address => uint256) public launchpegToRangeLength;
 
     /// @notice Contract uses VRF or pseudo-randomness
     bool public override useVRF;
@@ -70,17 +59,19 @@ contract BatchReveal is
     /// The default is 3
     uint16 public constant override requestConfirmations = 3;
 
-    /// @notice Next batch that will be revealed by VRF, if activated
-    uint256 public override nextBatchToReveal;
+    /// @notice Next batch that will be revealed by VRF (if activated) by launchpeg
+    mapping(address => uint256) public override launchpegToNextBatchToReveal;
 
-    /// @notice Has a batch been force revealed
+    /// @notice True when force revealed has been triggered for the given launchpeg
     /// @dev VRF will not be used anymore if a batch has been force revealed
-    bool public override hasBeenForceRevealed;
+    mapping(address => bool) public override launchpegToHasBeenForceRevealed;
 
-    /// @notice Has the random number for a batch already been asked
+    /// @notice Has the random number for a batch already been asked by launchpeg
     /// @dev Prevents people from spamming the random words request
     /// and therefore reveal more batches than expected
-    mapping(uint256 => bool) public override vrfRequestedForBatch;
+    mapping(address => mapping(uint256 => bool))
+        public
+        override launchpegToVrfRequestedForBatch;
 
     struct Range {
         int128 start;
@@ -88,21 +79,25 @@ contract BatchReveal is
     }
 
     /// @dev Emitted on revealNextBatch() and forceReveal()
+    /// @param baseLaunchpeg Base launchpeg address
     /// @param batchNumber The batch revealed
     /// @param batchSeed The random number drawn
-    event Reveal(uint256 batchNumber, uint256 batchSeed);
+    event Reveal(address baseLaunchpeg, uint256 batchNumber, uint256 batchSeed);
 
     /// @dev Emitted on setRevealBatchSize()
+    /// @param baseLaunchpeg Base launchpeg address
     /// @param revealBatchSize New reveal batch size
-    event RevealBatchSizeSet(uint256 revealBatchSize);
+    event RevealBatchSizeSet(address baseLaunchpeg, uint256 revealBatchSize);
 
     /// @dev Emitted on setRevealStartTime()
+    /// @param baseLaunchpeg Base launchpeg address
     /// @param revealStartTime New reveal start time
-    event RevealStartTimeSet(uint256 revealStartTime);
+    event RevealStartTimeSet(address baseLaunchpeg, uint256 revealStartTime);
 
     /// @dev Emitted on setRevealInterval()
+    /// @param baseLaunchpeg Base launchpeg address
     /// @param revealInterval New reveal interval
-    event RevealIntervalSet(uint256 revealInterval);
+    event RevealIntervalSet(address baseLaunchpeg, uint256 revealInterval);
 
     /// @dev emitted on setVRF()
     /// @param _vrfCoordinator Chainlink coordinator address
@@ -116,109 +111,152 @@ contract BatchReveal is
         uint32 _callbackGasLimit
     );
 
-    modifier batchRevealInitialized() {
-        if (!isBatchRevealInitialized()) {
+    /// @dev Verify that batch reveal is configured for the given launchpeg
+    modifier batchRevealInitialized(address _baseLaunchpeg) {
+        if (!isBatchRevealInitialized(_baseLaunchpeg)) {
             revert Launchpeg__BatchRevealNotInitialized();
         }
         _;
     }
 
-    modifier revealNotStarted() {
-        if (lastTokenRevealed != 0) {
+    /// @dev Verify that batch reveal hasn't started for the given launchpeg
+    modifier revealNotStarted(address _baseLaunchpeg) {
+        if (launchpegToLastTokenReveal[_baseLaunchpeg] != 0) {
             revert Launchpeg__BatchRevealStarted();
         }
         _;
     }
 
-    modifier onlyBaseLaunchpeg() {
-        if (msg.sender != baseLaunchpeg) revert Launchpeg__Unauthorized();
-        _;
+    /// @notice Initialize batch reveal
+    function initialize() external override initializer {
+        __Ownable_init();
     }
 
-    /// @dev BatchReveal initialization
+    /// @dev Configure batch reveal for a given launch
     /// @param _baseLaunchpeg Base launchpeg address
-    /// @param _revealBatchSize Size of the batch reveal.
+    /// @param _revealBatchSize Size of the batch reveal
     /// @param _revealStartTime Batch reveal start time
     /// @param _revealInterval Batch reveal interval
-    function initialize(
+    function configure(
         address _baseLaunchpeg,
         uint256 _revealBatchSize,
         uint256 _revealStartTime,
         uint256 _revealInterval
-    ) external override initializer {
-        __Ownable_init();
-
-        baseLaunchpeg = _baseLaunchpeg;
+    ) external override onlyOwner revealNotStarted(_baseLaunchpeg) {
         uint256 _collectionSize = IBaseLaunchpeg(_baseLaunchpeg)
             .collectionSize();
-        collectionSize = _collectionSize;
-        intCollectionSize = int128(int256(_collectionSize));
-        setRevealBatchSize(_revealBatchSize);
-        setRevealStartTime(_revealStartTime);
-        setRevealInterval(_revealInterval);
+        launchpegToConfig[_baseLaunchpeg].collectionSize = _collectionSize;
+        launchpegToConfig[_baseLaunchpeg].intCollectionSize = int128(
+            int256(_collectionSize)
+        );
+        _setRevealBatchSize(_baseLaunchpeg, _revealBatchSize);
+        _setRevealStartTime(_baseLaunchpeg, _revealStartTime);
+        _setRevealInterval(_baseLaunchpeg, _revealInterval);
     }
 
     /// @notice Set the reveal batch size. Can only be set after
     /// batch reveal has been initialized and before a batch has
     /// been revealed.
+    /// @param _baseLaunchpeg Base launchpeg address
     /// @param _revealBatchSize New reveal batch size
-    function setRevealBatchSize(uint256 _revealBatchSize)
+    function setRevealBatchSize(
+        address _baseLaunchpeg,
+        uint256 _revealBatchSize
+    )
         public
         override
         onlyOwner
-        batchRevealInitialized
-        revealNotStarted
+        batchRevealInitialized(_baseLaunchpeg)
+        revealNotStarted(_baseLaunchpeg)
     {
+        _setRevealBatchSize(_baseLaunchpeg, _revealBatchSize);
+    }
+
+    /// @notice Set the reveal batch size
+    /// @param _baseLaunchpeg Base launchpeg address
+    /// @param _revealBatchSize New reveal batch size
+    function _setRevealBatchSize(
+        address _baseLaunchpeg,
+        uint256 _revealBatchSize
+    ) internal {
         if (_revealBatchSize == 0) {
             revert Launchpeg__InvalidBatchRevealSize();
         }
+        uint256 collectionSize = launchpegToConfig[_baseLaunchpeg]
+            .collectionSize;
         if (
             collectionSize % _revealBatchSize != 0 ||
             _revealBatchSize > collectionSize
         ) {
             revert Launchpeg__InvalidBatchRevealSize();
         }
-        _rangeLength = (collectionSize / _revealBatchSize) * 2;
-        revealBatchSize = _revealBatchSize;
-        emit RevealBatchSizeSet(_revealBatchSize);
+        launchpegToRangeLength[_baseLaunchpeg] =
+            (collectionSize / _revealBatchSize) *
+            2;
+        launchpegToConfig[_baseLaunchpeg].revealBatchSize = _revealBatchSize;
+        emit RevealBatchSizeSet(_baseLaunchpeg, _revealBatchSize);
     }
 
     /// @notice Set the batch reveal start time. Can only be set after
     /// batch reveal has been initialized and before a batch has
     /// been revealed.
+    /// @param _baseLaunchpeg Base launchpeg address
     /// @param _revealStartTime New batch reveal start time
-    function setRevealStartTime(uint256 _revealStartTime)
+    function setRevealStartTime(
+        address _baseLaunchpeg,
+        uint256 _revealStartTime
+    )
         public
         override
         onlyOwner
-        batchRevealInitialized
-        revealNotStarted
+        batchRevealInitialized(_baseLaunchpeg)
+        revealNotStarted(_baseLaunchpeg)
     {
+        _setRevealStartTime(_baseLaunchpeg, _revealStartTime);
+    }
+
+    /// @notice Set the batch reveal start time.
+    /// @param _baseLaunchpeg Base launchpeg address
+    /// @param _revealStartTime New batch reveal start time
+    function _setRevealStartTime(
+        address _baseLaunchpeg,
+        uint256 _revealStartTime
+    ) internal {
         // probably a mistake if the reveal is more than 100 days in the future
         if (_revealStartTime > block.timestamp + 8_640_000) {
             revert Launchpeg__InvalidRevealDates();
         }
-        revealStartTime = _revealStartTime;
-        emit RevealStartTimeSet(_revealStartTime);
+        launchpegToConfig[_baseLaunchpeg].revealStartTime = _revealStartTime;
+        emit RevealStartTimeSet(_baseLaunchpeg, _revealStartTime);
     }
 
     /// @notice Set the batch reveal interval. Can only be set after
     /// batch reveal has been initialized and before a batch has
     /// been revealed.
+    /// @param _baseLaunchpeg Base launchpeg address
     /// @param _revealInterval New batch reveal interval
-    function setRevealInterval(uint256 _revealInterval)
+    function setRevealInterval(address _baseLaunchpeg, uint256 _revealInterval)
         public
         override
         onlyOwner
-        batchRevealInitialized
-        revealNotStarted
+        batchRevealInitialized(_baseLaunchpeg)
+        revealNotStarted(_baseLaunchpeg)
+    {
+        _setRevealInterval(_baseLaunchpeg, _revealInterval);
+    }
+
+    /// @notice Set the batch reveal interval.
+    /// @param _baseLaunchpeg Base launchpeg address
+    /// @param _revealInterval New batch reveal interval
+    function _setRevealInterval(address _baseLaunchpeg, uint256 _revealInterval)
+        internal
     {
         // probably a mistake if reveal interval is longer than 10 days
         if (_revealInterval > 864_000) {
             revert Launchpeg__InvalidRevealDates();
         }
-        revealInterval = _revealInterval;
-        emit RevealIntervalSet(_revealInterval);
+        launchpegToConfig[_baseLaunchpeg].revealInterval = _revealInterval;
+        emit RevealIntervalSet(_baseLaunchpeg, _revealInterval);
     }
 
     /// @notice Set VRF configuration
@@ -309,7 +347,8 @@ contract BatchReveal is
         Range[] memory _ranges,
         int128 _start,
         int128 _end,
-        uint256 _lastIndex
+        uint256 _lastIndex,
+        int128 _intCollectionSize
     ) private view returns (uint256) {
         uint256 positionToAssume = _lastIndex;
         for (uint256 j; j < _lastIndex; j++) {
@@ -334,69 +373,117 @@ contract BatchReveal is
         }
         _ranges[positionToAssume] = Range(
             _start,
-            _min(_end, intCollectionSize)
+            _min(_end, _intCollectionSize)
         );
         _lastIndex++;
-        if (_end > intCollectionSize) {
-            _addRange(_ranges, 0, _end - intCollectionSize, _lastIndex);
+        if (_end > _intCollectionSize) {
+            _addRange(
+                _ranges,
+                0,
+                _end - _intCollectionSize,
+                _lastIndex,
+                _intCollectionSize
+            );
             _lastIndex++;
         }
         return _lastIndex;
     }
 
     /// @dev Adds the last batch into the ranges array
+    /// @param _baseLaunchpeg Base launchpeg address
     /// @param _lastBatch Batch number to consider
+    /// @param _revealBatchSize Reveal batch size
+    /// @param _intCollectionSize Collection size
+    /// @param _rangeLength Range length
     /// @return ranges Ranges array filled with every URI taken by batches smaller or equal to lastBatch
-    function _buildJumps(uint256 _lastBatch)
-        private
-        view
-        returns (Range[] memory)
-    {
+    function _buildJumps(
+        address _baseLaunchpeg,
+        uint256 _lastBatch,
+        uint256 _revealBatchSize,
+        int128 _intCollectionSize,
+        uint256 _rangeLength
+    ) private view returns (Range[] memory) {
         Range[] memory ranges = new Range[](_rangeLength);
         uint256 lastIndex;
         for (uint256 i; i < _lastBatch; i++) {
             int128 start = int128(
-                int256(_getFreeTokenId(batchToSeed[i], ranges))
+                int256(
+                    _getFreeTokenId(
+                        _baseLaunchpeg,
+                        launchpegToBatchToSeed[_baseLaunchpeg][i],
+                        ranges,
+                        _intCollectionSize
+                    )
+                )
             );
-            int128 end = start + int128(int256(revealBatchSize));
-            lastIndex = _addRange(ranges, start, end, lastIndex);
+            int128 end = start + int128(int256(_revealBatchSize));
+            lastIndex = _addRange(
+                ranges,
+                start,
+                end,
+                lastIndex,
+                _intCollectionSize
+            );
         }
         return ranges;
     }
 
     /// @dev Gets the random token URI number from tokenId
+    /// @param _baseLaunchpeg Base launchpeg address
     /// @param _startId Token Id to consider
     /// @return uriId Revealed Token URI Id
-    function getShuffledTokenId(uint256 _startId)
+    function getShuffledTokenId(address _baseLaunchpeg, uint256 _startId)
         external
         view
         override
         returns (uint256)
     {
+        int128 intCollectionSize = launchpegToConfig[_baseLaunchpeg]
+            .intCollectionSize;
+        uint256 revealBatchSize = launchpegToConfig[_baseLaunchpeg]
+            .revealBatchSize;
         uint256 batch = _startId / revealBatchSize;
-        Range[] memory ranges = new Range[](_rangeLength);
+        Range[] memory ranges = new Range[](
+            launchpegToRangeLength[_baseLaunchpeg]
+        );
 
-        ranges = _buildJumps(batch);
+        ranges = _buildJumps(
+            _baseLaunchpeg,
+            batch,
+            revealBatchSize,
+            intCollectionSize,
+            launchpegToRangeLength[_baseLaunchpeg]
+        );
 
         uint256 positionsToMove = (_startId % revealBatchSize) +
-            batchToSeed[batch];
+            launchpegToBatchToSeed[_baseLaunchpeg][batch];
 
-        return _getFreeTokenId(positionsToMove, ranges);
+        return
+            _getFreeTokenId(
+                _baseLaunchpeg,
+                positionsToMove,
+                ranges,
+                intCollectionSize
+            );
     }
 
     /// @dev Gets the shifted URI number from tokenId and range array
+    /// @param _baseLaunchpeg Base launchpeg address
     /// @param _positionsToMoveStart Token URI offset if none of the URI Ids were taken
     /// @param _ranges Ranges array built by _buildJumps()
+    /// @param _intCollectionSize Collection size
     /// @return uriId Revealed Token URI Id
     function _getFreeTokenId(
+        address _baseLaunchpeg,
         uint256 _positionsToMoveStart,
-        Range[] memory _ranges
+        Range[] memory _ranges,
+        int128 _intCollectionSize
     ) private view returns (uint256) {
         int128 positionsToMove = int128(int256(_positionsToMoveStart));
         int128 id;
 
         for (uint256 round = 0; round < 2; round++) {
-            for (uint256 i; i < _rangeLength; i++) {
+            for (uint256 i; i < launchpegToRangeLength[_baseLaunchpeg]; i++) {
                 int128 start = _ranges[i].start;
                 int128 end = _ranges[i].end;
                 if (id < start) {
@@ -411,8 +498,8 @@ contract BatchReveal is
                     id = end;
                 }
             }
-            if ((id + positionsToMove) >= intCollectionSize) {
-                positionsToMove -= intCollectionSize - id;
+            if ((id + positionsToMove) >= _intCollectionSize) {
+                positionsToMove -= _intCollectionSize - id;
                 id = 0;
             }
         }
@@ -420,8 +507,16 @@ contract BatchReveal is
     }
 
     /// @dev Sets batch seed for specified batch number
+    /// @param _baseLaunchpeg Base launchpeg address
     /// @param _batchNumber Batch number that needs to be revealed
-    function _setBatchSeed(uint256 _batchNumber) internal {
+    /// @param _collectionSize Collection size
+    /// @param _revealBatchSize Reveal batch size
+    function _setBatchSeed(
+        address _baseLaunchpeg,
+        uint256 _batchNumber,
+        uint256 _collectionSize,
+        uint256 _revealBatchSize
+    ) internal {
         uint256 randomness = uint256(
             keccak256(
                 abi.encode(
@@ -437,21 +532,29 @@ contract BatchReveal is
         );
 
         // not perfectly random since the folding doesn't match bounds perfectly, but difference is small
-        batchToSeed[_batchNumber] =
+        launchpegToBatchToSeed[_baseLaunchpeg][_batchNumber] =
             randomness %
-            (collectionSize - (_batchNumber * revealBatchSize));
+            (_collectionSize - (_batchNumber * _revealBatchSize));
     }
 
     /// @dev Returns true if a batch can be revealed
+    /// @param _baseLaunchpeg Base launchpeg address
     /// @param _totalSupply Number of token already minted
     /// @return hasToRevealInfo Returns a bool saying whether a reveal can be triggered or not
     /// and the number of the next batch that will be revealed
-    function hasBatchToReveal(uint256 _totalSupply)
+    function hasBatchToReveal(address _baseLaunchpeg, uint256 _totalSupply)
         public
         view
         override
         returns (bool, uint256)
     {
+        uint256 revealBatchSize = launchpegToConfig[_baseLaunchpeg]
+            .revealBatchSize;
+        uint256 revealStartTime = launchpegToConfig[_baseLaunchpeg]
+            .revealStartTime;
+        uint256 revealInterval = launchpegToConfig[_baseLaunchpeg]
+            .revealInterval;
+        uint256 lastTokenRevealed = launchpegToLastTokenReveal[_baseLaunchpeg];
         uint256 batchNumber;
         unchecked {
             batchNumber = lastTokenRevealed / revealBatchSize;
@@ -461,7 +564,7 @@ contract BatchReveal is
         if (
             block.timestamp < revealStartTime + batchNumber * revealInterval ||
             _totalSupply < lastTokenRevealed + revealBatchSize ||
-            vrfRequestedForBatch[batchNumber]
+            launchpegToVrfRequestedForBatch[_baseLaunchpeg][batchNumber]
         ) {
             return (false, batchNumber);
         }
@@ -471,35 +574,55 @@ contract BatchReveal is
 
     /// @dev Reveals next batch if possible
     /// @dev If using VRF, the reveal happens on the coordinator callback call
+    /// @param _baseLaunchpeg Base launchpeg address
     /// @param _totalSupply Number of token already minted
     /// @return isRevealed Returns false if it is not possible to reveal the next batch
-    function revealNextBatch(uint256 _totalSupply)
+    function revealNextBatch(address _baseLaunchpeg, uint256 _totalSupply)
         external
         override
-        onlyBaseLaunchpeg
         returns (bool)
     {
+        if (_baseLaunchpeg != msg.sender) {
+            revert Launchpeg__Unauthorized();
+        }
+
         uint256 batchNumber;
         bool canReveal;
-        (canReveal, batchNumber) = hasBatchToReveal(_totalSupply);
+        (canReveal, batchNumber) = hasBatchToReveal(
+            _baseLaunchpeg,
+            _totalSupply
+        );
 
         if (!canReveal) {
             return false;
         }
 
         if (useVRF) {
-            VRFCoordinatorV2Interface(vrfCoordinator).requestRandomWords(
-                keyHash,
-                subscriptionId,
-                requestConfirmations,
-                callbackGasLimit,
-                1
-            );
-            vrfRequestedForBatch[batchNumber] = true;
+            uint256 requestId = VRFCoordinatorV2Interface(vrfCoordinator)
+                .requestRandomWords(
+                    keyHash,
+                    subscriptionId,
+                    requestConfirmations,
+                    callbackGasLimit,
+                    1
+                );
+            vrfRequestIdToLaunchpeg[requestId] = _baseLaunchpeg;
+            launchpegToVrfRequestedForBatch[_baseLaunchpeg][batchNumber] = true;
         } else {
-            lastTokenRevealed += revealBatchSize;
-            _setBatchSeed(batchNumber);
-            emit Reveal(batchNumber, batchToSeed[batchNumber]);
+            launchpegToLastTokenReveal[_baseLaunchpeg] += launchpegToConfig[
+                _baseLaunchpeg
+            ].revealBatchSize;
+            _setBatchSeed(
+                _baseLaunchpeg,
+                batchNumber,
+                launchpegToConfig[_baseLaunchpeg].collectionSize,
+                launchpegToConfig[_baseLaunchpeg].revealBatchSize
+            );
+            emit Reveal(
+                _baseLaunchpeg,
+                batchNumber,
+                launchpegToBatchToSeed[_baseLaunchpeg][batchNumber]
+            );
         }
 
         return true;
@@ -508,41 +631,70 @@ contract BatchReveal is
     /// @dev Callback triggered by the VRF coordinator
     /// @param _randomWords Array of random numbers provided by the VRF coordinator
     function fulfillRandomWords(
-        uint256, /* requestId */
+        uint256 requestId,
         uint256[] memory _randomWords
     ) internal override {
-        if (hasBeenForceRevealed) {
+        address baseLaunchpeg = vrfRequestIdToLaunchpeg[requestId];
+
+        if (launchpegToHasBeenForceRevealed[baseLaunchpeg]) {
             revert Launchpeg__HasBeenForceRevealed();
         }
 
-        uint256 _batchToReveal = nextBatchToReveal++;
+        uint256 revealBatchSize = launchpegToConfig[baseLaunchpeg]
+            .revealBatchSize;
+        uint256 collectionSize = launchpegToConfig[baseLaunchpeg]
+            .collectionSize;
+        uint256 _batchToReveal = launchpegToNextBatchToReveal[baseLaunchpeg]++;
         uint256 _revealBatchSize = revealBatchSize;
         uint256 _seed = _randomWords[0] %
             (collectionSize - (_batchToReveal * _revealBatchSize));
 
-        batchToSeed[_batchToReveal] = _seed;
-        lastTokenRevealed += _revealBatchSize;
+        launchpegToBatchToSeed[baseLaunchpeg][_batchToReveal] = _seed;
+        launchpegToLastTokenReveal[baseLaunchpeg] += _revealBatchSize;
 
-        emit Reveal(_batchToReveal, batchToSeed[_batchToReveal]);
+        emit Reveal(
+            baseLaunchpeg,
+            _batchToReveal,
+            launchpegToBatchToSeed[baseLaunchpeg][_batchToReveal]
+        );
     }
 
     /// @dev Force reveal, should be restricted to owner
-    function forceReveal() external override onlyOwner {
+    function forceReveal(address _baseLaunchpeg) external override onlyOwner {
+        uint256 revealBatchSize = launchpegToConfig[_baseLaunchpeg]
+            .revealBatchSize;
         uint256 batchNumber;
         unchecked {
-            batchNumber = lastTokenRevealed / revealBatchSize;
-            lastTokenRevealed += revealBatchSize;
+            batchNumber =
+                launchpegToLastTokenReveal[_baseLaunchpeg] /
+                revealBatchSize;
+            launchpegToLastTokenReveal[_baseLaunchpeg] += revealBatchSize;
         }
 
-        _setBatchSeed(batchNumber);
-        hasBeenForceRevealed = true;
-        emit Reveal(batchNumber, batchToSeed[batchNumber]);
+        _setBatchSeed(
+            _baseLaunchpeg,
+            batchNumber,
+            launchpegToConfig[_baseLaunchpeg].collectionSize,
+            launchpegToConfig[_baseLaunchpeg].revealBatchSize
+        );
+        launchpegToHasBeenForceRevealed[_baseLaunchpeg] = true;
+        emit Reveal(
+            _baseLaunchpeg,
+            batchNumber,
+            launchpegToBatchToSeed[_baseLaunchpeg][batchNumber]
+        );
     }
 
+    /// @notice Returns true if batch reveal is configured for the given launchpeg
     /// Since the collection size is only set on initialize()
     /// and the collection size cannot be 0, we assume a 0 value means
     /// the batch reveal configuration has not been initialized.
-    function isBatchRevealInitialized() public view override returns (bool) {
-        return collectionSize != 0;
+    function isBatchRevealInitialized(address _baseLaunchpeg)
+        public
+        view
+        override
+        returns (bool)
+    {
+        return launchpegToConfig[_baseLaunchpeg].collectionSize != 0;
     }
 }

--- a/contracts/FlatLaunchpeg.sol
+++ b/contracts/FlatLaunchpeg.sol
@@ -59,38 +59,32 @@ contract FlatLaunchpeg is BaseLaunchpeg, IFlatLaunchpeg {
     /// @param _symbol ERC721 symbol
     /// @param _projectOwner The project owner
     /// @param _royaltyReceiver Royalty fee collector
+    /// @param _batchReveal Batch reveal address
     /// @param _maxBatchSize Max amount of NFTs that can be minted at once
     /// @param _collectionSize The collection size (e.g 10000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
     /// @param _amountForAllowlist Amount of NFTs available for the allowlist mint (e.g 1000)
-    /// @param _batchRevealSize Size of the batch reveal
-    /// @param _revealStartTime Start of the token URIs reveal in seconds
-    /// @param _revealInterval Interval between two batch reveals in seconds
     function initialize(
         string memory _name,
         string memory _symbol,
         address _projectOwner,
         address _royaltyReceiver,
+        address _batchReveal,
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _amountForAllowlist,
-        uint256 _batchRevealSize,
-        uint256 _revealStartTime,
-        uint256 _revealInterval
+        uint256 _amountForAllowlist
     ) external override initializer {
         initializeBaseLaunchpeg(
             _name,
             _symbol,
             _projectOwner,
             _royaltyReceiver,
+            _batchReveal,
             _maxBatchSize,
             _collectionSize,
             _amountForDevs,
-            _amountForAllowlist,
-            _batchRevealSize,
-            _revealStartTime,
-            _revealInterval
+            _amountForAllowlist
         );
     }
 

--- a/contracts/Launchpeg.sol
+++ b/contracts/Launchpeg.sol
@@ -105,40 +105,34 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
     /// @param _symbol ERC721 symbol
     /// @param _projectOwner The project owner
     /// @param _royaltyReceiver Royalty fee collector
+    /// @param _batchReveal Batch reveal address
     /// @param _maxBatchSize Max amount of NFTs that can be minted at once
     /// @param _collectionSize The collection size (e.g 10000)
     /// @param _amountForAuction Amount of NFTs available for the auction (e.g 8000)
     /// @param _amountForAllowlist Amount of NFTs available for the allowlist mint (e.g 1000)
     /// @param _amountForDevs Amount of NFTs reserved for `projectOwner` (e.g 200)
-    /// @param _batchRevealSize Size of the batch reveal
-    /// @param _revealStartTime Start of the token URIs reveal in seconds
-    /// @param _revealInterval Interval between two batch reveals in seconds
     function initialize(
         string memory _name,
         string memory _symbol,
         address _projectOwner,
         address _royaltyReceiver,
+        address _batchReveal,
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForAuction,
         uint256 _amountForAllowlist,
-        uint256 _amountForDevs,
-        uint256 _batchRevealSize,
-        uint256 _revealStartTime,
-        uint256 _revealInterval
+        uint256 _amountForDevs
     ) external override initializer {
         initializeBaseLaunchpeg(
             _name,
             _symbol,
             _projectOwner,
             _royaltyReceiver,
+            _batchReveal,
             _maxBatchSize,
             _collectionSize,
             _amountForDevs,
-            _amountForAllowlist,
-            _batchRevealSize,
-            _revealStartTime,
-            _revealInterval
+            _amountForAllowlist
         );
         if (
             _amountForAuction + _amountForAllowlist + _amountForDevs >

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -6,6 +6,7 @@ error LaunchpegFactory__InvalidImplementation();
 error LaunchpegFactory__InvalidBatchReveal();
 
 // Launchpeg
+error Launchpeg__BatchRevealDisabled();
 error Launchpeg__BatchRevealNotInitialized();
 error Launchpeg__BatchRevealStarted();
 error Launchpeg__CanNotMintThisMany();

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -36,6 +36,7 @@ error Launchpeg__PublicSaleEndBeforePublicSaleStart();
 error Launchpeg__RevealNextBatchNotAvailable();
 error Launchpeg__TransferFailed();
 error Launchpeg__Unauthorized();
+error Launchpeg__WithdrawAVAXNotAvailable();
 error Launchpeg__WrongAddressesAndNumSlotsLength();
 error Launchpeg__WrongPhase();
 

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.4;
 
 // LaunchpegFactory
 error LaunchpegFactory__InvalidImplementation();
+error LaunchpegFactory__InvalidBatchReveal();
 
 // Launchpeg
 error Launchpeg__BatchRevealNotInitialized();

--- a/contracts/LaunchpegErrors.sol
+++ b/contracts/LaunchpegErrors.sol
@@ -13,6 +13,7 @@ error Launchpeg__HasBeenForceRevealed();
 error Launchpeg__JoeFeeAlreadyInitialized();
 error Launchpeg__InvalidAuctionDropInterval();
 error Launchpeg__InvalidStartTime();
+error Launchpeg__InvalidBatchReveal();
 error Launchpeg__InvalidBatchRevealSize();
 error Launchpeg__InvalidCallbackGasLimit();
 error Launchpeg__InvalidCoordinator();

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -157,7 +157,7 @@ contract LaunchpegFactory is
             _symbol,
             _projectOwner,
             _royaltyReceiver,
-            _initializeBatchReveal(_collectionSize, _batchRevealData),
+            _initializeBatchReveal(launchpeg, _batchRevealData),
             _maxBatchSize,
             _collectionSize,
             _amountForAuction,
@@ -225,7 +225,7 @@ contract LaunchpegFactory is
             _symbol,
             _projectOwner,
             _royaltyReceiver,
-            _initializeBatchReveal(_collectionSize, _batchRevealData),
+            _initializeBatchReveal(flatLaunchpeg, _batchRevealData),
             _maxBatchSize,
             _collectionSize,
             _amountForDevs,
@@ -316,14 +316,14 @@ contract LaunchpegFactory is
     }
 
     function _initializeBatchReveal(
-        uint256 _collectionSize,
+        address _baseLaunchpeg,
         BatchReveal calldata _batchRevealData
     ) private returns (address) {
         address batchReveal = Clones.clone(batchRevealImplementation);
 
         IBatchReveal(batchReveal).initialize(
+            _baseLaunchpeg,
             _batchRevealData.batchRevealSize,
-            _collectionSize,
             _batchRevealData.revealStartTime,
             _batchRevealData.revealInterval
         );

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -45,13 +45,6 @@ contract LaunchpegFactory is
         uint256 amountForAllowlist
     );
 
-    event BatchRevealCreated(
-        address indexed batchReveal,
-        uint256 batchRevealSize,
-        uint256 revealStartTime,
-        uint256 revealInterval
-    );
-
     event SetLaunchpegImplementation(address indexed launchpegImplementation);
     event SetFlatLaunchpegImplementation(
         address indexed flatLaunchpegImplementation

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/proxy/Clones.sol";
 
 import "./interfaces/ILaunchpegFactory.sol";
 import "./interfaces/ILaunchpeg.sol";
+import "./interfaces/IBatchReveal.sol";
 import "./interfaces/IFlatLaunchpeg.sol";
 import "./interfaces/IPendingOwnableUpgradeable.sol";
 import "./LaunchpegErrors.sol";
@@ -61,6 +62,8 @@ contract LaunchpegFactory is
     address public override launchpegImplementation;
     /// @notice FlatLaunchpeg contract to be cloned
     address public override flatLaunchpegImplementation;
+    /// @notice BatchReveal contract to be cloned;
+    address public override batchRevealImplementation;
 
     /// @notice Default fee percentage
     /// @dev In basis points e.g 100 for 1%
@@ -154,14 +157,12 @@ contract LaunchpegFactory is
             _symbol,
             _projectOwner,
             _royaltyReceiver,
+            _initializeBatchReveal(_collectionSize, _batchRevealData),
             _maxBatchSize,
             _collectionSize,
             _amountForAuction,
             _amountForAllowlist,
-            _amountForDevs,
-            _batchRevealData.batchRevealSize,
-            _batchRevealData.revealStartTime,
-            _batchRevealData.revealInterval
+            _amountForDevs
         );
 
         IBaseLaunchpeg(launchpeg).initializeJoeFee(
@@ -224,13 +225,11 @@ contract LaunchpegFactory is
             _symbol,
             _projectOwner,
             _royaltyReceiver,
+            _initializeBatchReveal(_collectionSize, _batchRevealData),
             _maxBatchSize,
             _collectionSize,
             _amountForDevs,
-            _amountForAllowlist,
-            _batchRevealData.batchRevealSize,
-            _batchRevealData.revealStartTime,
-            _batchRevealData.revealInterval
+            _amountForAllowlist
         );
 
         IBaseLaunchpeg(flatLaunchpeg).initializeJoeFee(
@@ -314,5 +313,21 @@ contract LaunchpegFactory is
 
         joeFeeCollector = _joeFeeCollector;
         emit SetDefaultJoeFeeCollector(_joeFeeCollector);
+    }
+
+    function _initializeBatchReveal(
+        uint256 _collectionSize,
+        BatchReveal calldata _batchRevealData
+    ) private returns (address) {
+        address batchReveal = Clones.clone(batchRevealImplementation);
+
+        IBatchReveal(batchReveal).initialize(
+            _batchRevealData.batchRevealSize,
+            _collectionSize,
+            _batchRevealData.revealStartTime,
+            _batchRevealData.revealInterval
+        );
+
+        return batchReveal;
     }
 }

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -328,6 +328,8 @@ contract LaunchpegFactory is
             _batchRevealData.revealInterval
         );
 
+        OwnableUpgradeable(batchReveal).transferOwnership(msg.sender);
+
         return batchReveal;
     }
 }

--- a/contracts/LaunchpegLens.sol
+++ b/contracts/LaunchpegLens.sol
@@ -100,12 +100,17 @@ contract LaunchpegLens {
     /// @notice LaunchpegFactory address
     address public immutable launchpegFactory;
 
+    /// @notice BatchReveal address
+    address public immutable batchReveal;
+
     /// @dev LaunchpegLens constructor
-    /// @param _launchpegFactory Address of the LaunchpegFactory
-    constructor(address _launchpegFactory) {
+    /// @param _launchpegFactory LaunchpegFactory address
+    /// @param _batchReveal BatchReveal address
+    constructor(address _launchpegFactory, address _batchReveal) {
         launchpegInterface = type(ILaunchpeg).interfaceId;
         flatLaunchpegInterface = type(IFlatLaunchpeg).interfaceId;
         launchpegFactory = _launchpegFactory;
+        batchReveal = _batchReveal;
     }
 
     /// @notice Gets the type of Launchpeg
@@ -190,14 +195,18 @@ contract LaunchpegLens {
             .unrevealedURI();
         data.collectionData.baseURI = IBaseLaunchpeg(_launchpeg).baseURI();
 
-        data.revealData.revealBatchSize = IBatchReveal(_launchpeg)
-            .revealBatchSize();
-        data.revealData.lastTokenRevealed = IBatchReveal(_launchpeg)
-            .lastTokenRevealed();
-        data.revealData.revealStartTime = IBatchReveal(_launchpeg)
-            .revealStartTime();
-        data.revealData.revealInterval = IBatchReveal(_launchpeg)
-            .revealInterval();
+        (
+            ,
+            ,
+            uint256 revealBatchSize,
+            uint256 revealStartTime,
+            uint256 revealInterval
+        ) = IBatchReveal(batchReveal).launchpegToConfig(_launchpeg);
+        data.revealData.revealBatchSize = revealBatchSize;
+        data.revealData.revealStartTime = revealStartTime;
+        data.revealData.revealInterval = revealInterval;
+        data.revealData.lastTokenRevealed = IBatchReveal(batchReveal)
+            .launchpegToLastTokenReveal(_launchpeg);
 
         if (data.launchType == LaunchpegType.Launchpeg) {
             data.launchpegData.amountForAuction = ILaunchpeg(_launchpeg)

--- a/contracts/interfaces/IBaseLaunchpeg.sol
+++ b/contracts/interfaces/IBaseLaunchpeg.sol
@@ -86,4 +86,8 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
     function numberMinted(address owner) external view returns (uint256);
 
     function currentPhase() external view returns (Phase);
+
+    function revealNextBatch() external;
+
+    function hasBatchToReveal() external view returns (bool, uint256);
 }

--- a/contracts/interfaces/IBaseLaunchpeg.sol
+++ b/contracts/interfaces/IBaseLaunchpeg.sol
@@ -52,6 +52,8 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
 
     function publicSaleEndTime() external view returns (uint256);
 
+    function withdrawAVAXStartTime() external view returns (uint256);
+
     function initializeJoeFee(uint256 _joeFeePercent, address _joeFeeCollector)
         external;
 
@@ -82,6 +84,8 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
     function setRevealStartTime(uint256 _revealStartTime) external;
 
     function setRevealInterval(uint256 _revealInterval) external;
+
+    function setWithdrawAVAXStartTime(uint256 _withdrawAVAXStartTime) external;
 
     function devMint(uint256 quantity) external;
 

--- a/contracts/interfaces/IBaseLaunchpeg.sol
+++ b/contracts/interfaces/IBaseLaunchpeg.sol
@@ -68,34 +68,15 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
 
     function setUnrevealedURI(string calldata baseURI) external;
 
-    function setVRF(
-        address _vrfCoordinator,
-        bytes32 _keyHash,
-        uint64 _subscriptionId,
-        uint32 _callbackGasLimit
-    ) external;
-
     function setPublicSaleStartTime(uint256 _publicSaleStartTime) external;
 
     function setPublicSaleEndTime(uint256 _publicSaleEndTime) external;
-
-    function setRevealBatchSize(uint256 _revealBatchSize) external;
-
-    function setRevealStartTime(uint256 _revealStartTime) external;
-
-    function setRevealInterval(uint256 _revealInterval) external;
 
     function setWithdrawAVAXStartTime(uint256 _withdrawAVAXStartTime) external;
 
     function devMint(uint256 quantity) external;
 
     function withdrawAVAX(address to) external;
-
-    function revealNextBatch() external;
-
-    function forceReveal() external;
-
-    function hasBatchToReveal() external view returns (bool, uint256);
 
     function getOwnershipData(uint256 tokenId)
         external

--- a/contracts/interfaces/IBatchReveal.sol
+++ b/contracts/interfaces/IBatchReveal.sol
@@ -6,8 +6,8 @@ pragma solidity ^0.8.4;
 /// @notice Defines the basic interface of BaseLaunchpeg
 interface IBatchReveal {
     function initialize(
+        address _baseLaunchpeg,
         uint256 _revealBatchSize,
-        uint256 _collectionSize,
         uint256 _revealStartTime,
         uint256 _revealInterval
     ) external;
@@ -24,6 +24,8 @@ interface IBatchReveal {
         uint64 _subscriptionId,
         uint32 _callbackGasLimit
     ) external;
+
+    function baseLaunchpeg() external view returns (address);
 
     function revealBatchSize() external view returns (uint256);
 

--- a/contracts/interfaces/IBatchReveal.sol
+++ b/contracts/interfaces/IBatchReveal.sol
@@ -58,8 +58,6 @@ interface IBatchReveal {
         view
         returns (uint256);
 
-    function isBatchRevealEnabled() external view returns (bool);
-
     function isBatchRevealInitialized() external view returns (bool);
 
     function revealNextBatch(uint256 _totalSupply) external returns (bool);

--- a/contracts/interfaces/IBatchReveal.sol
+++ b/contracts/interfaces/IBatchReveal.sol
@@ -59,4 +59,13 @@ interface IBatchReveal {
     function isBatchRevealEnabled() external view returns (bool);
 
     function isBatchRevealInitialized() external view returns (bool);
+
+    function revealNextBatch(uint256 _totalSupply) external returns (bool);
+
+    function hasBatchToReveal(uint256 _totalSupply)
+        external
+        view
+        returns (bool, uint256);
+
+    function forceReveal() external;
 }

--- a/contracts/interfaces/IBatchReveal.sol
+++ b/contracts/interfaces/IBatchReveal.sol
@@ -1,22 +1,45 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-/// @title IBaseLaunchpeg
+/// @title IBatchReveal
 /// @author Trader Joe
-/// @notice Defines the basic interface of BaseLaunchpeg
+/// @notice Defines the basic interface of BatchReveal
 interface IBatchReveal {
-    function initialize(
+    struct BatchRevealConfig {
+        uint256 collectionSize;
+        int128 intCollectionSize;
+        /// @notice Size of the batch reveal
+        /// @dev Must divide collectionSize
+        uint256 revealBatchSize;
+        /// @notice Timestamp for the start of the reveal process
+        /// @dev Can be set to zero for immediate reveal after token mint
+        uint256 revealStartTime;
+        /// @notice Time interval for gradual reveal
+        /// @dev Can be set to zero in order to reveal the collection all at once
+        uint256 revealInterval;
+    }
+
+    function initialize() external;
+
+    function configure(
         address _baseLaunchpeg,
         uint256 _revealBatchSize,
         uint256 _revealStartTime,
         uint256 _revealInterval
     ) external;
 
-    function setRevealBatchSize(uint256 _revealBatchSize) external;
+    function setRevealBatchSize(
+        address _baseLaunchpeg,
+        uint256 _revealBatchSize
+    ) external;
 
-    function setRevealStartTime(uint256 _revealStartTime) external;
+    function setRevealStartTime(
+        address _baseLaunchpeg,
+        uint256 _revealStartTime
+    ) external;
 
-    function setRevealInterval(uint256 _revealInterval) external;
+    function setRevealInterval(address _baseLaunchpeg, uint256 _revealInterval)
+        external;
 
     function setVRF(
         address _vrfCoordinator,
@@ -25,17 +48,26 @@ interface IBatchReveal {
         uint32 _callbackGasLimit
     ) external;
 
-    function baseLaunchpeg() external view returns (address);
+    function launchpegToConfig(address)
+        external
+        view
+        returns (
+            uint256,
+            int128,
+            uint256,
+            uint256,
+            uint256
+        );
 
-    function revealBatchSize() external view returns (uint256);
+    function launchpegToBatchToSeed(address, uint256)
+        external
+        view
+        returns (uint256);
 
-    function batchToSeed(uint256) external view returns (uint256);
-
-    function lastTokenRevealed() external view returns (uint256);
-
-    function revealStartTime() external view returns (uint256);
-
-    function revealInterval() external view returns (uint256);
+    function launchpegToLastTokenReveal(address)
+        external
+        view
+        returns (uint256);
 
     function useVRF() external view returns (bool);
 
@@ -47,25 +79,39 @@ interface IBatchReveal {
 
     function requestConfirmations() external view returns (uint16);
 
-    function nextBatchToReveal() external view returns (uint256);
-
-    function hasBeenForceRevealed() external view returns (bool);
-
-    function vrfRequestedForBatch(uint256) external view returns (bool);
-
-    function getShuffledTokenId(uint256 _startId)
+    function launchpegToNextBatchToReveal(address)
         external
         view
         returns (uint256);
 
-    function isBatchRevealInitialized() external view returns (bool);
+    function launchpegToHasBeenForceRevealed(address)
+        external
+        view
+        returns (bool);
 
-    function revealNextBatch(uint256 _totalSupply) external returns (bool);
+    function launchpegToVrfRequestedForBatch(address, uint256)
+        external
+        view
+        returns (bool);
 
-    function hasBatchToReveal(uint256 _totalSupply)
+    function getShuffledTokenId(address _baseLaunchpeg, uint256 _startId)
+        external
+        view
+        returns (uint256);
+
+    function isBatchRevealInitialized(address _baseLaunchpeg)
+        external
+        view
+        returns (bool);
+
+    function revealNextBatch(address _baseLaunchpeg, uint256 _totalSupply)
+        external
+        returns (bool);
+
+    function hasBatchToReveal(address _baseLaunchpeg, uint256 _totalSupply)
         external
         view
         returns (bool, uint256);
 
-    function forceReveal() external;
+    function forceReveal(address _baseLaunchpeg) external;
 }

--- a/contracts/interfaces/IBatchReveal.sol
+++ b/contracts/interfaces/IBatchReveal.sol
@@ -12,6 +12,19 @@ interface IBatchReveal {
         uint256 _revealInterval
     ) external;
 
+    function setRevealBatchSize(uint256 _revealBatchSize) external;
+
+    function setRevealStartTime(uint256 _revealStartTime) external;
+
+    function setRevealInterval(uint256 _revealInterval) external;
+
+    function setVRF(
+        address _vrfCoordinator,
+        bytes32 _keyHash,
+        uint64 _subscriptionId,
+        uint32 _callbackGasLimit
+    ) external;
+
     function revealBatchSize() external view returns (uint256);
 
     function batchToSeed(uint256) external view returns (uint256);

--- a/contracts/interfaces/IBatchReveal.sol
+++ b/contracts/interfaces/IBatchReveal.sol
@@ -5,6 +5,13 @@ pragma solidity ^0.8.4;
 /// @author Trader Joe
 /// @notice Defines the basic interface of BaseLaunchpeg
 interface IBatchReveal {
+    function initialize(
+        uint256 _revealBatchSize,
+        uint256 _collectionSize,
+        uint256 _revealStartTime,
+        uint256 _revealInterval
+    ) external;
+
     function revealBatchSize() external view returns (uint256);
 
     function batchToSeed(uint256) external view returns (uint256);

--- a/contracts/interfaces/IBatchReveal.sol
+++ b/contracts/interfaces/IBatchReveal.sol
@@ -30,4 +30,13 @@ interface IBatchReveal {
     function hasBeenForceRevealed() external view returns (bool);
 
     function vrfRequestedForBatch(uint256) external view returns (bool);
+
+    function getShuffledTokenId(uint256 _startId)
+        external
+        view
+        returns (uint256);
+
+    function isBatchRevealEnabled() external view returns (bool);
+
+    function isBatchRevealInitialized() external view returns (bool);
 }

--- a/contracts/interfaces/IFlatLaunchpeg.sol
+++ b/contracts/interfaces/IFlatLaunchpeg.sol
@@ -21,13 +21,11 @@ interface IFlatLaunchpeg is IBaseLaunchpeg {
         string memory _symbol,
         address _projectOwner,
         address _royaltyReceiver,
+        address _batchReveal,
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForDevs,
-        uint256 _amountForAllowlist,
-        uint256 _batchRevealSize,
-        uint256 _revealStartTime,
-        uint256 _revealInterval
+        uint256 _amountForAllowlist
     ) external;
 
     function initializePhases(

--- a/contracts/interfaces/ILaunchpeg.sol
+++ b/contracts/interfaces/ILaunchpeg.sol
@@ -34,14 +34,12 @@ interface ILaunchpeg is IBaseLaunchpeg {
         string memory _symbol,
         address _projectOwner,
         address _royaltyReceiver,
+        address _batchReveal,
         uint256 _maxBatchSize,
         uint256 _collectionSize,
         uint256 _amountForAuction,
         uint256 _amountForAllowlist,
-        uint256 _amountForDevs,
-        uint256 _batchRevealSize,
-        uint256 _revealStartTime,
-        uint256 _revealInterval
+        uint256 _amountForDevs
     ) external;
 
     function initializePhases(

--- a/contracts/interfaces/ILaunchpegFactory.sol
+++ b/contracts/interfaces/ILaunchpegFactory.sol
@@ -9,7 +9,7 @@ interface ILaunchpegFactory {
 
     function flatLaunchpegImplementation() external view returns (address);
 
-    function batchRevealImplementation() external view returns (address);
+    function batchReveal() external view returns (address);
 
     function joeFeePercent() external view returns (uint256);
 
@@ -53,19 +53,14 @@ interface ILaunchpegFactory {
         uint256 _amountForAllowlist
     ) external returns (address);
 
-    function createBatchReveal(
-        address baseLaunchpeg,
-        uint256 batchRevealSize,
-        uint256 revealStartTime,
-        uint256 revealInterval
-    ) external returns (address);
-
     function setLaunchpegImplementation(address _launchpegImplementation)
         external;
 
     function setFlatLaunchpegImplementation(
         address _flatLaunchpegImplementation
     ) external;
+
+    function setBatchReveal(address _batchReveal) external;
 
     function setDefaultJoeFeePercent(uint256 _joeFeePercent) external;
 

--- a/contracts/interfaces/ILaunchpegFactory.sol
+++ b/contracts/interfaces/ILaunchpegFactory.sol
@@ -15,6 +15,8 @@ interface ILaunchpegFactory {
 
     function flatLaunchpegImplementation() external view returns (address);
 
+    function batchRevealImplementation() external view returns (address);
+
     function joeFeePercent() external view returns (uint256);
 
     function joeFeeCollector() external view returns (address);

--- a/test/FlatLaunchpeg.test.ts
+++ b/test/FlatLaunchpeg.test.ts
@@ -480,11 +480,23 @@ describe('FlatLaunchpeg', () => {
     })
 
     it("Can't withdraw before start time", async () => {
+      const blockTimestamp = await latest()
+      config.withdrawAVAXStartTime = blockTimestamp.add(duration.days(1))
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
 
-      const blockTimestamp = await latest()
-      await flatLaunchpeg.setWithdrawAVAXStartTime(blockTimestamp.add(duration.hours(1)))
+      await expect(flatLaunchpeg.connect(projectOwner).withdrawAVAX(projectOwner.address)).to.be.revertedWith(
+        'Launchpeg__WithdrawAVAXNotAvailable()'
+      )
+    })
 
+    it("Can't set start time before current block timestamp", async () => {
+      const blockTimestamp = await latest()
+      await expect(flatLaunchpeg.setWithdrawAVAXStartTime(blockTimestamp.sub(duration.minutes(1)))).to.be.revertedWith(
+        'Launchpeg__InvalidStartTime()'
+      )
+    })
+
+    it("Can't withdraw when start time not initialized", async () => {
       await expect(flatLaunchpeg.connect(projectOwner).withdrawAVAX(projectOwner.address)).to.be.revertedWith(
         'Launchpeg__WithdrawAVAXNotAvailable()'
       )

--- a/test/FlatLaunchpeg.test.ts
+++ b/test/FlatLaunchpeg.test.ts
@@ -44,6 +44,7 @@ describe('FlatLaunchpeg', () => {
   })
 
   const deployFlatLaunchpeg = async () => {
+    batchReveal = await batchRevealCF.deploy()
     flatLaunchpeg = await flatLaunchpegCF.deploy()
     await flatLaunchpeg.initialize(
       'JoePEG',
@@ -56,13 +57,9 @@ describe('FlatLaunchpeg', () => {
       config.amountForDevs,
       config.amountForAllowlist
     )
-  }
-
-  const deployBatchReveal = async () => {
-    batchReveal = await batchRevealCF.deploy()
     await batchReveal.initialize(
+      flatLaunchpeg.address,
       config.batchRevealSize,
-      config.collectionSize,
       config.batchRevealStart,
       config.batchRevealInterval
     )
@@ -70,7 +67,6 @@ describe('FlatLaunchpeg', () => {
 
   beforeEach(async () => {
     config = { ...(await getDefaultLaunchpegConfig()) }
-    await deployBatchReveal()
     await deployFlatLaunchpeg()
   })
 

--- a/test/FlatLaunchpeg.test.ts
+++ b/test/FlatLaunchpeg.test.ts
@@ -43,8 +43,12 @@ describe('FlatLaunchpeg', () => {
     })
   })
 
-  const deployFlatLaunchpeg = async () => {
+  const deployBatchReveal = async () => {
     batchReveal = await batchRevealCF.deploy()
+    await batchReveal.initialize()
+  }
+
+  const deployFlatLaunchpeg = async () => {
     flatLaunchpeg = await flatLaunchpegCF.deploy()
     await flatLaunchpeg.initialize(
       'JoePEG',
@@ -56,17 +60,18 @@ describe('FlatLaunchpeg', () => {
       config.amountForDevs,
       config.amountForAllowlist
     )
-    await batchReveal.initialize(
+    await flatLaunchpeg.setBatchReveal(batchReveal.address)
+    await batchReveal.configure(
       flatLaunchpeg.address,
       config.batchRevealSize,
       config.batchRevealStart,
       config.batchRevealInterval
     )
-    await flatLaunchpeg.setBatchReveal(batchReveal.address)
   }
 
   beforeEach(async () => {
     config = { ...(await getDefaultLaunchpegConfig()) }
+    await deployBatchReveal()
     await deployFlatLaunchpeg()
   })
 
@@ -284,42 +289,45 @@ describe('FlatLaunchpeg', () => {
       const invalidRevealBatchSize = 101
       const newRevealBatchSize = 100
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(batchReveal.connect(projectOwner).setRevealBatchSize(newRevealBatchSize)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-      await expect(batchReveal.setRevealBatchSize(invalidRevealBatchSize)).to.be.revertedWith(
+      await expect(
+        batchReveal.connect(projectOwner).setRevealBatchSize(flatLaunchpeg.address, newRevealBatchSize)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
+      await expect(batchReveal.setRevealBatchSize(flatLaunchpeg.address, invalidRevealBatchSize)).to.be.revertedWith(
         'Launchpeg__InvalidBatchRevealSize()'
       )
-      await batchReveal.setRevealBatchSize(newRevealBatchSize)
-      expect(await batchReveal.revealBatchSize()).to.eq(newRevealBatchSize)
+      await batchReveal.setRevealBatchSize(flatLaunchpeg.address, newRevealBatchSize)
+      const batchRevealConfig = await batchReveal.launchpegToConfig(flatLaunchpeg.address)
+      expect(batchRevealConfig[2]).to.eq(newRevealBatchSize)
     })
 
     it('Should allow owner to set reveal start time', async () => {
       const invalidRevealStartTime = config.batchRevealStart.add(duration.minutes(8_640_000))
       const newRevealStartTime = config.batchRevealStart.add(duration.minutes(30))
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(batchReveal.connect(projectOwner).setRevealStartTime(newRevealStartTime)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-      await expect(batchReveal.setRevealStartTime(invalidRevealStartTime)).to.be.revertedWith(
+      await expect(
+        batchReveal.connect(projectOwner).setRevealStartTime(flatLaunchpeg.address, newRevealStartTime)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
+      await expect(batchReveal.setRevealStartTime(flatLaunchpeg.address, invalidRevealStartTime)).to.be.revertedWith(
         'Launchpeg__InvalidRevealDates()'
       )
-      await batchReveal.setRevealStartTime(newRevealStartTime)
-      expect(await batchReveal.revealStartTime()).to.eq(newRevealStartTime)
+      await batchReveal.setRevealStartTime(flatLaunchpeg.address, newRevealStartTime)
+      const batchRevealConfig = await batchReveal.launchpegToConfig(flatLaunchpeg.address)
+      expect(batchRevealConfig[3]).to.eq(newRevealStartTime)
     })
 
     it('Should allow owner to set reveal interval', async () => {
       const invalidRevealInterval = 864_001
       const newRevealInterval = config.batchRevealInterval.add(10)
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(batchReveal.connect(projectOwner).setRevealInterval(newRevealInterval)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-      await expect(batchReveal.setRevealInterval(invalidRevealInterval)).to.be.revertedWith(
+      await expect(
+        batchReveal.connect(projectOwner).setRevealInterval(flatLaunchpeg.address, newRevealInterval)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
+      await expect(batchReveal.setRevealInterval(flatLaunchpeg.address, invalidRevealInterval)).to.be.revertedWith(
         'Launchpeg__InvalidRevealDates()'
       )
-      await batchReveal.setRevealInterval(newRevealInterval)
-      expect(await batchReveal.revealInterval()).to.eq(newRevealInterval)
+      await batchReveal.setRevealInterval(flatLaunchpeg.address, newRevealInterval)
+      const batchRevealConfig = await batchReveal.launchpegToConfig(flatLaunchpeg.address)
+      expect(batchRevealConfig[4]).to.eq(newRevealInterval)
     })
   })
 

--- a/test/FlatLaunchpeg.test.ts
+++ b/test/FlatLaunchpeg.test.ts
@@ -115,10 +115,9 @@ describe('FlatLaunchpeg', () => {
       )
     })
 
-    it('Should allow 0 batch reveal size', async () => {
+    it('Should not allow 0 batch reveal size', async () => {
       config.batchRevealSize = 0
-      await deployFlatLaunchpeg()
-      expect(await batchReveal.revealBatchSize()).to.eq(0)
+      await expect(deployFlatLaunchpeg()).to.be.revertedWith('Launchpeg__InvalidBatchRevealSize()')
     })
 
     it('Should not allow invalid reveal batch size', async () => {

--- a/test/Launchpeg.test.ts
+++ b/test/Launchpeg.test.ts
@@ -46,10 +46,12 @@ describe('Launchpeg', () => {
     })
   })
 
+  const deployBatchReveal = async () => {
+    batchReveal = await batchRevealCF.deploy()
+    await batchReveal.initialize()
+  }
+
   const deployLaunchpeg = async (isBatchRevealEnabled: boolean = true) => {
-    if (isBatchRevealEnabled) {
-      batchReveal = await batchRevealCF.deploy()
-    }
     launchpeg = await launchpegCF.deploy()
     await launchpeg.initialize(
       'JoePEG',
@@ -63,7 +65,7 @@ describe('Launchpeg', () => {
       config.amountForDevs
     )
     if (isBatchRevealEnabled) {
-      await batchReveal.initialize(
+      await batchReveal.configure(
         launchpeg.address,
         config.batchRevealSize,
         config.batchRevealStart,
@@ -79,6 +81,7 @@ describe('Launchpeg', () => {
 
   beforeEach(async () => {
     config = { ...(await getDefaultLaunchpegConfig()) }
+    await deployBatchReveal()
     await deployLaunchpeg()
   })
 
@@ -200,10 +203,8 @@ describe('Launchpeg', () => {
     })
 
     it('Batch reveal dates must be coherent', async () => {
-      batchReveal = await batchRevealCF.deploy()
-
       await expect(
-        batchReveal.initialize(
+        batchReveal.configure(
           launchpeg.address,
           config.batchRevealSize,
           config.batchRevealStart.add(8_640_000),
@@ -212,7 +213,7 @@ describe('Launchpeg', () => {
       ).to.be.revertedWith('Launchpeg__InvalidRevealDates()')
 
       await expect(
-        batchReveal.initialize(
+        batchReveal.configure(
           launchpeg.address,
           config.batchRevealSize,
           config.batchRevealStart,
@@ -222,15 +223,15 @@ describe('Launchpeg', () => {
     })
 
     it('Should not allow batch reveal config to be set prior to batch reveal initialization', async () => {
-      batchReveal = await batchRevealCF.deploy()
-      await expect(batchReveal.setRevealBatchSize(config.batchRevealSize)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
+      await deployBatchReveal()
+      await expect(batchReveal.setRevealBatchSize(launchpeg.address, config.batchRevealSize)).to.be.revertedWith(
+        'Launchpeg__BatchRevealNotInitialized'
       )
-      await expect(batchReveal.setRevealStartTime(config.batchRevealStart)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
+      await expect(batchReveal.setRevealStartTime(launchpeg.address, config.batchRevealStart)).to.be.revertedWith(
+        'Launchpeg__BatchRevealNotInitialized'
       )
-      await expect(batchReveal.setRevealInterval(config.batchRevealInterval)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
+      await expect(batchReveal.setRevealInterval(launchpeg.address, config.batchRevealInterval)).to.be.revertedWith(
+        'Launchpeg__BatchRevealNotInitialized'
       )
     })
 
@@ -466,42 +467,45 @@ describe('Launchpeg', () => {
       const invalidRevealBatchSize = 101
       const newRevealBatchSize = 100
       await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
-      await expect(batchReveal.connect(projectOwner).setRevealBatchSize(newRevealBatchSize)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-      await expect(batchReveal.setRevealBatchSize(invalidRevealBatchSize)).to.be.revertedWith(
+      await expect(
+        batchReveal.connect(projectOwner).setRevealBatchSize(launchpeg.address, newRevealBatchSize)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
+      await expect(batchReveal.setRevealBatchSize(launchpeg.address, invalidRevealBatchSize)).to.be.revertedWith(
         'Launchpeg__InvalidBatchRevealSize()'
       )
-      await batchReveal.setRevealBatchSize(newRevealBatchSize)
-      expect(await batchReveal.revealBatchSize()).to.eq(newRevealBatchSize)
+      await batchReveal.setRevealBatchSize(launchpeg.address, newRevealBatchSize)
+      const batchRevealConfig = await batchReveal.launchpegToConfig(launchpeg.address)
+      expect(batchRevealConfig[2]).to.eq(newRevealBatchSize)
     })
 
     it('Should allow owner to set reveal start time', async () => {
       const invalidRevealStartTime = config.batchRevealStart.add(duration.minutes(8_640_000))
       const newRevealStartTime = config.batchRevealStart.add(duration.minutes(30))
       await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
-      await expect(batchReveal.connect(projectOwner).setRevealStartTime(newRevealStartTime)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-      await expect(batchReveal.setRevealStartTime(invalidRevealStartTime)).to.be.revertedWith(
+      await expect(
+        batchReveal.connect(projectOwner).setRevealStartTime(launchpeg.address, newRevealStartTime)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
+      await expect(batchReveal.setRevealStartTime(launchpeg.address, invalidRevealStartTime)).to.be.revertedWith(
         'Launchpeg__InvalidRevealDates()'
       )
-      await batchReveal.setRevealStartTime(newRevealStartTime)
-      expect(await batchReveal.revealStartTime()).to.eq(newRevealStartTime)
+      await batchReveal.setRevealStartTime(launchpeg.address, newRevealStartTime)
+      const batchRevealConfig = await batchReveal.launchpegToConfig(launchpeg.address)
+      expect(batchRevealConfig[3]).to.eq(newRevealStartTime)
     })
 
     it('Should allow owner to set reveal interval', async () => {
       const invalidRevealInterval = 864_001
       const newRevealInterval = config.batchRevealInterval.add(10)
       await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
-      await expect(batchReveal.connect(projectOwner).setRevealInterval(newRevealInterval)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-      await expect(batchReveal.setRevealInterval(invalidRevealInterval)).to.be.revertedWith(
+      await expect(
+        batchReveal.connect(projectOwner).setRevealInterval(launchpeg.address, newRevealInterval)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
+      await expect(batchReveal.setRevealInterval(launchpeg.address, invalidRevealInterval)).to.be.revertedWith(
         'Launchpeg__InvalidRevealDates()'
       )
-      await batchReveal.setRevealInterval(newRevealInterval)
-      expect(await batchReveal.revealInterval()).to.eq(newRevealInterval)
+      await batchReveal.setRevealInterval(launchpeg.address, newRevealInterval)
+      const batchRevealConfig = await batchReveal.launchpegToConfig(launchpeg.address)
+      expect(batchRevealConfig[4]).to.eq(newRevealInterval)
     })
   })
 
@@ -1004,9 +1008,11 @@ describe('Launchpeg', () => {
         'Launchpeg__RevealNextBatchNotAvailable'
       )
 
-      await expect(batchReveal.connect(bob).forceReveal()).to.be.revertedWith('Ownable: caller is not the owner')
+      await expect(batchReveal.connect(bob).forceReveal(launchpeg.address)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
 
-      await batchReveal.connect(dev).forceReveal()
+      await batchReveal.connect(dev).forceReveal(launchpeg.address)
       // Batch 1 is revealed
       expect(await launchpeg.tokenURI(0)).to.contains(config.baseTokenURI)
       expect(await launchpeg.tokenURI(config.batchRevealSize)).to.be.equal(config.unrevealedTokenURI)
@@ -1021,7 +1027,7 @@ describe('Launchpeg', () => {
       const newRevealBatchSize = 5
       await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
       await launchpeg.connect(alice).revealNextBatch()
-      await expect(batchReveal.setRevealBatchSize(newRevealBatchSize)).to.be.revertedWith(
+      await expect(batchReveal.setRevealBatchSize(launchpeg.address, newRevealBatchSize)).to.be.revertedWith(
         'Launchpeg__BatchRevealStarted()'
       )
     })
@@ -1035,7 +1041,7 @@ describe('Launchpeg', () => {
       const newRevealStartTime = config.batchRevealStart.add(duration.minutes(30))
       await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
       await launchpeg.connect(alice).revealNextBatch()
-      await expect(batchReveal.setRevealStartTime(newRevealStartTime)).to.be.revertedWith(
+      await expect(batchReveal.setRevealStartTime(launchpeg.address, newRevealStartTime)).to.be.revertedWith(
         'Launchpeg__BatchRevealStarted()'
       )
     })
@@ -1049,7 +1055,7 @@ describe('Launchpeg', () => {
       const newRevealInterval = config.batchRevealInterval.add(10)
       await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
       await launchpeg.connect(alice).revealNextBatch()
-      await expect(batchReveal.setRevealInterval(newRevealInterval)).to.be.revertedWith(
+      await expect(batchReveal.setRevealInterval(launchpeg.address, newRevealInterval)).to.be.revertedWith(
         'Launchpeg__BatchRevealStarted()'
       )
     })
@@ -1120,7 +1126,7 @@ describe('Launchpeg', () => {
       await launchpeg.revealNextBatch()
       expect(await launchpeg.tokenURI(3)).to.eq('unrevealed')
 
-      await batchReveal.connect(dev).forceReveal()
+      await batchReveal.connect(dev).forceReveal(launchpeg.address)
       const token3URI = await launchpeg.tokenURI(3)
       expect(token3URI).to.contains('base')
       expect(await launchpeg.tokenURI(3 + config.batchRevealSize)).to.eq('unrevealed')

--- a/test/Launchpeg.test.ts
+++ b/test/Launchpeg.test.ts
@@ -46,19 +46,9 @@ describe('Launchpeg', () => {
     })
   })
 
-  const deployBatchReveal = async () => {
-    batchReveal = await batchRevealCF.deploy()
-    await batchReveal.initialize(
-      config.batchRevealSize,
-      config.collectionSize,
-      config.batchRevealStart,
-      config.batchRevealInterval
-    )
-  }
-
   const deployLaunchpeg = async () => {
+    batchReveal = await batchRevealCF.deploy()
     launchpeg = await launchpegCF.deploy()
-
     await launchpeg.initialize(
       'JoePEG',
       'JOEPEG',
@@ -71,6 +61,12 @@ describe('Launchpeg', () => {
       config.amountForAllowlist,
       config.amountForDevs
     )
+    await batchReveal.initialize(
+      launchpeg.address,
+      config.batchRevealSize,
+      config.batchRevealStart,
+      config.batchRevealInterval
+    )
   }
 
   const setVRF = async () => {
@@ -79,7 +75,6 @@ describe('Launchpeg', () => {
 
   beforeEach(async () => {
     config = { ...(await getDefaultLaunchpegConfig()) }
-    await deployBatchReveal()
     await deployLaunchpeg()
   })
 
@@ -206,8 +201,8 @@ describe('Launchpeg', () => {
 
       await expect(
         batchReveal.initialize(
+          launchpeg.address,
           config.batchRevealSize,
-          config.collectionSize,
           config.batchRevealStart.add(8_640_000),
           config.batchRevealInterval
         )
@@ -215,8 +210,8 @@ describe('Launchpeg', () => {
 
       await expect(
         batchReveal.initialize(
+          launchpeg.address,
           config.batchRevealSize,
-          config.collectionSize,
           config.batchRevealStart,
           config.batchRevealInterval.add(864_000)
         )
@@ -815,7 +810,7 @@ describe('Launchpeg', () => {
   describe('Batch reveal on mint', () => {
     it('Invalid batch reveal size should be blocked', async () => {
       config.batchRevealSize = 49
-      await expect(deployBatchReveal()).to.be.revertedWith('Launchpeg__InvalidBatchRevealSize()')
+      await expect(deployLaunchpeg()).to.be.revertedWith('Launchpeg__InvalidBatchRevealSize()')
     })
 
     it('NFTs should be unrevealed initially', async () => {
@@ -839,7 +834,6 @@ describe('Launchpeg', () => {
       config.batchRevealSize = 10
       config.batchRevealStart = BigNumber.from(0)
       config.batchRevealInterval = BigNumber.from(0)
-      await deployBatchReveal()
       await deployLaunchpeg()
       await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
 
@@ -874,7 +868,6 @@ describe('Launchpeg', () => {
       config.batchRevealSize = 10
       config.batchRevealStart = BigNumber.from(0)
       config.batchRevealInterval = BigNumber.from(0)
-      await deployBatchReveal()
       await deployLaunchpeg()
 
       await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
@@ -898,7 +891,6 @@ describe('Launchpeg', () => {
       config.amountForAuction = 0
       config.amountForAllowlist = 0
       config.batchRevealSize = 10
-      await deployBatchReveal()
       await deployLaunchpeg()
       await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
 
@@ -923,7 +915,6 @@ describe('Launchpeg', () => {
       config.amountForAuction = 0
       config.amountForAllowlist = 0
       config.batchRevealSize = 10
-      await deployBatchReveal()
       await deployLaunchpeg()
 
       await initializePhasesLaunchpeg(launchpeg, config, Phase.Reveal)
@@ -948,7 +939,6 @@ describe('Launchpeg', () => {
     it('User cannot reveal batch if batch reveal is disabled', async () => {
       config.amountForDevs = 10
       config.batchRevealSize = 0
-      await deployBatchReveal()
       await deployLaunchpeg()
       await initializePhasesLaunchpeg(launchpeg, config, Phase.Reveal)
 
@@ -989,7 +979,6 @@ describe('Launchpeg', () => {
     it('Owner cannot set reveal batch size once batch reveal has started', async () => {
       config.amountForDevs = 10
       config.batchRevealSize = 10
-      await deployBatchReveal()
       await deployLaunchpeg()
       await initializePhasesLaunchpeg(launchpeg, config, Phase.Reveal)
 
@@ -1004,7 +993,6 @@ describe('Launchpeg', () => {
     it('Owner cannot set reveal time once batch reveal has started', async () => {
       config.amountForDevs = 10
       config.batchRevealSize = 10
-      await deployBatchReveal()
       await deployLaunchpeg()
       await initializePhasesLaunchpeg(launchpeg, config, Phase.Reveal)
 
@@ -1019,7 +1007,6 @@ describe('Launchpeg', () => {
     it('Owner cannot set reveal interval once batch reveal has started', async () => {
       config.amountForDevs = 10
       config.batchRevealSize = 10
-      await deployBatchReveal()
       await deployLaunchpeg()
       await initializePhasesLaunchpeg(launchpeg, config, Phase.Reveal)
 
@@ -1046,7 +1033,6 @@ describe('Launchpeg', () => {
       config.batchRevealSize = 10
       config.batchRevealStart = BigNumber.from(0)
       config.batchRevealInterval = BigNumber.from(0)
-      await deployBatchReveal()
       await deployLaunchpeg()
       await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
       await coordinatorMock.addConsumer(0, batchReveal.address)

--- a/test/Launchpeg.test.ts
+++ b/test/Launchpeg.test.ts
@@ -866,6 +866,18 @@ describe('Launchpeg', () => {
       expect(await launchpeg.tokenURI(0)).to.be.equal(config.unrevealedTokenURI)
     })
 
+    it('revealNextBatch reverts when batch reveal disabled', async () => {
+      await launchpeg.setBatchReveal(ethers.constants.AddressZero)
+      await expect(launchpeg.revealNextBatch()).to.be.revertedWith('Launchpeg__BatchRevealDisabled()')
+    })
+
+    it('hasBatchToReveal returns false when batch reveal disabled', async () => {
+      await launchpeg.setBatchReveal(ethers.constants.AddressZero)
+      const hasBatchToReveal = await launchpeg.hasBatchToReveal()
+      expect(hasBatchToReveal[0]).to.equal(false)
+      expect(hasBatchToReveal[1]).to.equal(0)
+    })
+
     it('Should reveal NFTs immediately if batch reveal is disabled', async () => {
       const isBatchRevealEnabled = false
       const tokenId = 0

--- a/test/Launchpeg.test.ts
+++ b/test/Launchpeg.test.ts
@@ -785,6 +785,19 @@ describe('Launchpeg', () => {
       )
     })
 
+    it("Can't set start time before current block timestamp", async () => {
+      const blockTimestamp = await latest()
+      await expect(launchpeg.setWithdrawAVAXStartTime(blockTimestamp.sub(duration.minutes(1)))).to.be.revertedWith(
+        'Launchpeg__InvalidStartTime()'
+      )
+    })
+
+    it("Can't withdraw when start time not initialized", async () => {
+      await expect(launchpeg.connect(projectOwner).withdrawAVAX(projectOwner.address)).to.be.revertedWith(
+        'Launchpeg__WithdrawAVAXNotAvailable()'
+      )
+    })
+
     it('Invalid fee setup should be blocked', async () => {
       let feePercent = 10001
       let feeCollector = bob

--- a/test/LaunchpegFactory.test.ts
+++ b/test/LaunchpegFactory.test.ts
@@ -56,6 +56,7 @@ describe('LaunchpegFactory', () => {
 
   const deployBatchReveal = async () => {
     batchReveal = await batchRevealCF.deploy()
+    await batchReveal.initialize()
   }
 
   const deployLaunchpeg = async () => {
@@ -93,6 +94,7 @@ describe('LaunchpegFactory', () => {
     launchpegFactory = await upgrades.deployProxy(launchpegFactoryCF, [
       launchpeg.address,
       flatLaunchpeg.address,
+      batchReveal.address,
       200,
       royaltyReceiver.address,
     ])
@@ -109,6 +111,7 @@ describe('LaunchpegFactory', () => {
         upgrades.deployProxy(launchpegFactoryCF, [
           ethers.constants.AddressZero,
           flatLaunchpeg.address,
+          batchReveal.address,
           200,
           royaltyReceiver.address,
         ])
@@ -118,10 +121,23 @@ describe('LaunchpegFactory', () => {
         upgrades.deployProxy(launchpegFactoryCF, [
           launchpeg.address,
           ethers.constants.AddressZero,
+          batchReveal.address,
           200,
           royaltyReceiver.address,
         ])
       ).to.be.revertedWith('LaunchpegFactory__InvalidImplementation()')
+    })
+
+    it('Should revert with batch reveal zero address', async () => {
+      await expect(
+        upgrades.deployProxy(launchpegFactoryCF, [
+          launchpeg.address,
+          flatLaunchpeg.address,
+          ethers.constants.AddressZero,
+          200,
+          royaltyReceiver.address,
+        ])
+      ).to.be.revertedWith('LaunchpegFactory__InvalidBatchReveal()')
     })
 
     it('Invalid default fees should be blocked', async () => {
@@ -129,6 +145,7 @@ describe('LaunchpegFactory', () => {
         upgrades.deployProxy(launchpegFactoryCF, [
           launchpeg.address,
           flatLaunchpeg.address,
+          batchReveal.address,
           10_001,
           royaltyReceiver.address,
         ])
@@ -140,6 +157,7 @@ describe('LaunchpegFactory', () => {
         upgrades.deployProxy(launchpegFactoryCF, [
           launchpeg.address,
           flatLaunchpeg.address,
+          batchReveal.address,
           200,
           ethers.constants.AddressZero,
         ])

--- a/test/LaunchpegFactory.test.ts
+++ b/test/LaunchpegFactory.test.ts
@@ -8,9 +8,12 @@ describe('LaunchpegFactory', () => {
   let launchpegCF: ContractFactory
   let flatLaunchpegCF: ContractFactory
   let launchpegFactoryCF: ContractFactory
+  let batchRevealCF: ContractFactory
+
   let launchpeg: Contract
   let flatLaunchpeg: Contract
   let launchpegFactory: Contract
+  let batchReveal: Contract
 
   let config: LaunchpegConfig
 
@@ -25,6 +28,7 @@ describe('LaunchpegFactory', () => {
     launchpegCF = await ethers.getContractFactory('Launchpeg')
     flatLaunchpegCF = await ethers.getContractFactory('FlatLaunchpeg')
     launchpegFactoryCF = await ethers.getContractFactory('LaunchpegFactory')
+    batchRevealCF = await ethers.getContractFactory('BatchReveal')
 
     signers = await ethers.getSigners()
     dev = signers[0]
@@ -45,9 +49,14 @@ describe('LaunchpegFactory', () => {
     })
 
     config = { ...(await getDefaultLaunchpegConfig()) }
+    await deployBatchReveal()
     await deployLaunchpeg()
     await deployFlatLaunchpeg()
   })
+
+  const deployBatchReveal = async () => {
+    batchReveal = await batchRevealCF.deploy()
+  }
 
   const deployLaunchpeg = async () => {
     launchpeg = await launchpegCF.deploy()
@@ -57,14 +66,12 @@ describe('LaunchpegFactory', () => {
       'JOEPEG',
       projectOwner.address,
       royaltyReceiver.address,
+      batchReveal.address,
       config.maxBatchSize,
       config.collectionSize,
       config.amountForAuction,
       config.amountForAllowlist,
-      config.amountForDevs,
-      config.batchRevealSize,
-      config.batchRevealStart,
-      config.batchRevealInterval
+      config.amountForDevs
     )
   }
 
@@ -76,13 +83,11 @@ describe('LaunchpegFactory', () => {
       'JOEPEG',
       projectOwner.address,
       royaltyReceiver.address,
+      batchReveal.address,
       config.maxBatchSize,
       config.collectionSize,
       config.amountForDevs,
-      config.amountForAllowlist,
-      config.batchRevealSize,
-      config.batchRevealStart,
-      config.batchRevealInterval
+      config.amountForAllowlist
     )
   }
 

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -24,8 +24,10 @@ export interface LaunchpegConfig {
   unrevealedTokenURI: string
   flatPublicSalePrice: BigNumber
   flatAllowlistSalePrice: BigNumber
+  withdrawAVAXStartTime: BigNumber
 }
 
+const WITHDRAW_AVAX_START_OFFSET = 1
 const AUCTION_START_OFFSET = 10
 const ALLOWLIST_START_OFFSET = 100
 const PUBLIC_SALE_START_OFFSET = 200
@@ -34,7 +36,8 @@ const REVEAL_START_OFFSET = 400
 const REVEAL_INTERVAL = 50
 
 export const getDefaultLaunchpegConfig = async (): Promise<LaunchpegConfig> => {
-  const auctionStartTime = (await latest()).add(duration.minutes(AUCTION_START_OFFSET))
+  const blockTimestamp = await latest()
+  const auctionStartTime = blockTimestamp.add(duration.minutes(AUCTION_START_OFFSET))
   return {
     auctionStartTime,
     allowlistStartTime: auctionStartTime.add(duration.minutes(ALLOWLIST_START_OFFSET)),
@@ -57,6 +60,7 @@ export const getDefaultLaunchpegConfig = async (): Promise<LaunchpegConfig> => {
     unrevealedTokenURI: 'unrevealed',
     flatPublicSalePrice: ethers.utils.parseUnits('1', 18),
     flatAllowlistSalePrice: ethers.utils.parseUnits('0.5', 18),
+    withdrawAVAXStartTime: blockTimestamp.add(duration.minutes(WITHDRAW_AVAX_START_OFFSET)),
   }
 }
 
@@ -83,6 +87,7 @@ export const initializePhasesLaunchpeg = async (launchpeg: Contract, config: Lau
   )
   await launchpeg.setUnrevealedURI(config.unrevealedTokenURI)
   await launchpeg.setBaseURI(config.baseTokenURI)
+  await launchpeg.setWithdrawAVAXStartTime(config.withdrawAVAXStartTime)
   await advanceTimeAndBlockToPhase(currentPhase)
 }
 
@@ -100,6 +105,7 @@ export const initializePhasesFlatLaunchpeg = async (
   )
   await flatLaunchpeg.setUnrevealedURI(config.unrevealedTokenURI)
   await flatLaunchpeg.setBaseURI(config.baseTokenURI)
+  await flatLaunchpeg.setWithdrawAVAXStartTime(config.withdrawAVAXStartTime)
   await advanceTimeAndBlockToPhase(currentPhase)
 }
 


### PR DESCRIPTION
This PR:
- BaseLaunchpeg no longer inherits from BatchReveal : this solves the issue with the contract size being greather than 24kb
- BatchReveal is now an independent contract that manages the reveal of all launchpeg contracts
- Adds `withdrawAVAXStartTime` to only allow project owner to withdraw at a specific time 