### PR TITLE
fix bug with numberMintedWithPreMint() calculation

### DIFF
--- a/contracts/BaseLaunchpeg.sol
+++ b/contracts/BaseLaunchpeg.sol
@@ -66,8 +66,8 @@ abstract contract BaseLaunchpeg is
     /// the pre-mint or allowlist mint
     mapping(address => uint256) public override allowlist;
 
-    // @notice The no. of NFTs pre-minted by the user address
-    mapping(address => uint256) public override userAddressToAmountPreMinted;
+    // @notice The remaining no. of pre-minted NFTs for the user address
+    mapping(address => uint256) public override userAddressToPreMintAmount;
 
     /// @notice Tracks the amount of NFTs minted by `projectOwner`
     uint256 public override amountMintedByDevs;
@@ -446,7 +446,7 @@ abstract contract BaseLaunchpeg is
             revert Launchpeg__MaxSupplyReached();
         }
         allowlist[msg.sender] -= _quantity;
-        userAddressToAmountPreMinted[msg.sender] += _quantity;
+        userAddressToPreMintAmount[msg.sender] += _quantity;
         amountMintedDuringPreMint += _quantity;
         preMintQueue.push(
             PreMintData({sender: msg.sender, quantity: _quantity})
@@ -484,6 +484,7 @@ abstract contract BaseLaunchpeg is
                 i++;
             }
             remQuantity -= quantity;
+            userAddressToPreMintAmount[sender] -= quantity;
             _mint(sender, quantity, "", false);
             emit Mint(
                 sender,
@@ -662,6 +663,6 @@ abstract contract BaseLaunchpeg is
         view
         returns (uint256)
     {
-        return _numberMinted(_owner) + userAddressToAmountPreMinted[_owner];
+        return _numberMinted(_owner) + userAddressToPreMintAmount[_owner];
     }
 }

--- a/contracts/interfaces/IBaseLaunchpeg.sol
+++ b/contracts/interfaces/IBaseLaunchpeg.sol
@@ -108,7 +108,7 @@ interface IBaseLaunchpeg is IERC721Upgradeable, IERC721MetadataUpgradeable {
         view
         returns (ERC721AUpgradeable.TokenOwnership memory);
 
-    function userAddressToAmountPreMinted(address owner)
+    function userAddressToPreMintAmount(address owner)
         external
         view
         returns (uint256);

--- a/test/Launchpeg.test.ts
+++ b/test/Launchpeg.test.ts
@@ -557,7 +557,7 @@ describe('Launchpeg', () => {
     it('Should allow whitelisted user to pre-mint', async () => {
       const quantity = 1
       await launchpeg.connect(alice).preMint(quantity, { value: allowlistPrice.mul(quantity) })
-      expect(await launchpeg.userAddressToAmountPreMinted(alice.address)).to.eq(quantity)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity)
       expect(await launchpeg.amountMintedDuringPreMint()).to.eq(quantity)
       expect(await launchpeg.numberMinted(alice.address)).to.eq(0)
 
@@ -569,7 +569,7 @@ describe('Launchpeg', () => {
     it('Should receive allowlist price per NFT', async () => {
       const quantity = 2
       await launchpeg.connect(alice).preMint(quantity, { value: allowlistPrice.mul(quantity) })
-      expect(await launchpeg.userAddressToAmountPreMinted(alice.address)).to.eq(quantity)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity)
 
       await expect(launchpeg.connect(alice).preMint(1)).to.be.revertedWith('Launchpeg__NotEnoughAVAX(0)')
     })
@@ -579,7 +579,7 @@ describe('Launchpeg', () => {
       const quantity = 3
       const remQuantity = allowlistQty - quantity
       await launchpeg.connect(alice).preMint(quantity, { value: allowlistPrice.mul(quantity) })
-      expect(await launchpeg.userAddressToAmountPreMinted(alice.address)).to.eq(quantity)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity)
       expect(await launchpeg.allowlist(alice.address)).to.eq(remQuantity)
 
       await expect(
@@ -587,7 +587,7 @@ describe('Launchpeg', () => {
       ).to.be.revertedWith('Launchpeg__NotEligibleForAllowlistMint()')
 
       await launchpeg.connect(alice).preMint(remQuantity, { value: allowlistPrice.mul(remQuantity) })
-      expect(await launchpeg.userAddressToAmountPreMinted(alice.address)).to.eq(quantity + remQuantity)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity + remQuantity)
     })
 
     it('Should not allow 0 pre-mint amount', async () => {
@@ -596,7 +596,7 @@ describe('Launchpeg', () => {
 
     it('Should not transfer pre-minted NFT to user', async () => {
       await launchpeg.connect(alice).preMint(1, { value: allowlistPrice })
-      expect(await launchpeg.userAddressToAmountPreMinted(alice.address)).to.eq(1)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(1)
       expect(await launchpeg.balanceOf(alice.address)).to.eq(0)
     })
 
@@ -616,8 +616,8 @@ describe('Launchpeg', () => {
         'Launchpeg__MaxSupplyReached()'
       )
 
-      expect(await launchpeg.userAddressToAmountPreMinted(alice.address)).to.eq(aliceQty)
-      expect(await launchpeg.userAddressToAmountPreMinted(bob.address)).to.eq(bobQty)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(aliceQty)
+      expect(await launchpeg.userAddressToPreMintAmount(bob.address)).to.eq(bobQty)
       expect(await launchpeg.amountMintedDuringPreMint()).to.eq(aliceQty + bobQty)
     })
 
@@ -732,6 +732,8 @@ describe('Launchpeg', () => {
       expect(await launchpeg.balanceOf(alice.address)).to.eq(10)
       expect(await launchpeg.balanceOf(bob.address)).to.eq(5)
       expect(await launchpeg.amountBatchMinted()).to.eq(15)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(0)
+      expect(await launchpeg.userAddressToPreMintAmount(bob.address)).to.eq(0)
 
       await expect(launchpeg.batchMintPreMintedNFTs(5)).to.be.revertedWith('Launchpeg__MaxSupplyForBatchMintReached()')
     })
@@ -877,6 +879,7 @@ describe('Launchpeg', () => {
       await launchpeg.connect(alice).batchMintPreMintedNFTs(2)
       expect(await launchpeg.balanceOf(alice.address)).to.eq(2)
       expect(await launchpeg.amountBatchMinted()).to.eq(2)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(0)
 
       await expect(launchpeg.batchMintPreMintedNFTs(5)).to.be.revertedWith('Launchpeg__MaxSupplyForBatchMintReached()')
     })


### PR DESCRIPTION
This PR fixes a bug with the `_numberMintedWithPreMint()` calculation. This method counted pre-minted NFTs twice - once in the pre-mint, and again when you batchMint() since that increments the `_numberMinted()`. 