### PR TITLE
re-factor tests to remove duplicate tests; add batch reveal tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,16 @@ yarn verify-fuji
 ```
 
 ## Test coverage
-Test coverage on current commit `fc0f3b5` is the following :
+Test coverage on commit `90c3341` is the following :
 File                   |  % Stmts | % Branch |  % Funcs |  % Lines |
 -----------------------|----------|----------|----------|----------|
-  BaseLaunchpeg.sol    |    98.61 |     91.3 |    94.74 |    94.68 |
+  BaseLaunchpeg.sol    |    99.19 |    94.87 |       96 |    96.84 |
   BatchReveal.sol      |      100 |      100 |      100 |      100 |
-  FlatLaunchpeg.sol    |    95.24 |    91.67 |       80 |    92.59 |
-  Launchpeg.sol        |    96.97 |    92.86 |    90.91 |       95 |
+  FlatLaunchpeg.sol    |    98.04 |      100 |    91.67 |    98.41 |
+  Launchpeg.sol        |    98.89 |      100 |    94.12 |    99.09 |
+  LaunchpegErrors.sol  |      100 |      100 |      100 |      100 |
   LaunchpegFactory.sol |      100 |      100 |      100 |      100 |
-  **All files**        |    98.51 |    94.12 |    94.34 |    96.58 |
+  **All files**        |    99.35 |    98.41 |    96.63 |    98.75 |
 
 Coverage was calculated by the `solidity-coverage` plugin from hardhat.
 

--- a/contracts/BatchReveal.sol
+++ b/contracts/BatchReveal.sol
@@ -687,7 +687,7 @@ contract BatchReveal is
     }
 
     /// @notice Returns true if batch reveal is configured for the given launchpeg
-    /// Since the collection size is only set on initialize()
+    /// Since the collection size is set only when batch reveal is initialized,
     /// and the collection size cannot be 0, we assume a 0 value means
     /// the batch reveal configuration has not been initialized.
     function isBatchRevealInitialized(address _baseLaunchpeg)

--- a/contracts/Launchpeg.sol
+++ b/contracts/Launchpeg.sol
@@ -451,6 +451,7 @@ contract Launchpeg is BaseLaunchpeg, ILaunchpeg {
             preMintStartTime == 0 ||
             allowlistStartTime == 0 ||
             publicSaleStartTime == 0 ||
+            publicSaleEndTime == 0 ||
             block.timestamp < auctionSaleStartTime
         ) {
             return Phase.NotStarted;

--- a/contracts/LaunchpegFactory.sol
+++ b/contracts/LaunchpegFactory.sol
@@ -7,10 +7,10 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import "./interfaces/ILaunchpegFactory.sol";
-import "./interfaces/ILaunchpeg.sol";
 import "./interfaces/IBatchReveal.sol";
 import "./interfaces/IFlatLaunchpeg.sol";
+import "./interfaces/ILaunchpeg.sol";
+import "./interfaces/ILaunchpegFactory.sol";
 import "./interfaces/IPendingOwnableUpgradeable.sol";
 import "./interfaces/ISafePausableUpgradeable.sol";
 import "./LaunchpegErrors.sol";

--- a/test/BaseLaunchpeg.test.ts
+++ b/test/BaseLaunchpeg.test.ts
@@ -1,0 +1,914 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import { ContractFactory, Contract, BigNumber, Bytes } from 'ethers'
+import { config as hardhatConfig, ethers, network } from 'hardhat'
+import { initializePhasesLaunchpeg, getDefaultLaunchpegConfig, Phase, LaunchpegConfig } from './utils/helpers'
+import { advanceTimeAndBlock, latest, duration } from './utils/time'
+
+describe('Launchpeg', () => {
+  let launchpegCF: ContractFactory
+  let batchRevealCF: ContractFactory
+  let launchpeg: Contract
+  let batchReveal: Contract
+
+  let config: LaunchpegConfig
+
+  let signers: SignerWithAddress[]
+  let dev: SignerWithAddress
+  let alice: SignerWithAddress
+  let bob: SignerWithAddress
+  let projectOwner: SignerWithAddress
+  let royaltyReceiver: SignerWithAddress
+
+  before(async () => {
+    launchpegCF = await ethers.getContractFactory('Launchpeg')
+    batchRevealCF = await ethers.getContractFactory('BatchReveal')
+
+    signers = await ethers.getSigners()
+    dev = signers[0]
+    alice = signers[1]
+    bob = signers[2]
+    projectOwner = signers[3]
+    royaltyReceiver = signers[4]
+
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [
+        {
+          live: false,
+          saveDeployments: true,
+          tags: ['test', 'local'],
+        },
+      ],
+    })
+  })
+
+  const deployBatchReveal = async () => {
+    batchReveal = await batchRevealCF.deploy()
+    await batchReveal.initialize()
+  }
+
+  const deployLaunchpeg = async () => {
+    launchpeg = await launchpegCF.deploy()
+    await launchpeg.initialize(
+      'JoePEG',
+      'JOEPEG',
+      projectOwner.address,
+      royaltyReceiver.address,
+      config.maxBatchSize,
+      config.collectionSize,
+      config.amountForAuction,
+      config.amountForAllowlist,
+      config.amountForDevs
+    )
+    await batchReveal.configure(
+      launchpeg.address,
+      config.batchRevealSize,
+      config.batchRevealStart,
+      config.batchRevealInterval
+    )
+    await launchpeg.setBatchReveal(batchReveal.address)
+  }
+
+  beforeEach(async () => {
+    config = await getDefaultLaunchpegConfig()
+    await deployBatchReveal()
+    await deployLaunchpeg()
+  })
+
+  describe('Initialize Launchpeg', () => {
+    it('Should allow owner to initialize only once', async () => {
+      expect(await launchpeg.collectionSize()).to.eq(config.collectionSize)
+      expect(await launchpeg.amountForDevs()).to.eq(config.amountForDevs)
+      expect(await launchpeg.amountForAllowlist()).to.eq(config.amountForAllowlist)
+      expect(await launchpeg.maxBatchSize()).to.eq(config.maxBatchSize)
+      expect(await launchpeg.maxPerAddressDuringMint()).to.eq(config.maxBatchSize)
+
+      await expect(
+        launchpeg.initialize(
+          'JoePEG',
+          'JOEPEG',
+          projectOwner.address,
+          royaltyReceiver.address,
+          config.maxBatchSize,
+          config.collectionSize,
+          config.amountForAuction,
+          config.amountForAllowlist,
+          config.amountForDevs
+        )
+      ).to.be.revertedWith('Initializable: contract is already initialized')
+    })
+
+    it('Should revert if project owner is zero address', async () => {
+      launchpeg = await launchpegCF.deploy()
+      await expect(
+        launchpeg.initialize(
+          'JoePEG',
+          'JOEPEG',
+          ethers.constants.AddressZero,
+          royaltyReceiver.address,
+          config.maxBatchSize,
+          config.collectionSize,
+          config.amountForAuction,
+          config.amountForAllowlist,
+          config.amountForDevs
+        )
+      ).to.be.revertedWith('Launchpeg__InvalidProjectOwner()')
+    })
+
+    it('Should revert if collection size is 0', async () => {
+      config.collectionSize = 0
+      await expect(deployLaunchpeg()).to.be.revertedWith('Launchpeg__LargerCollectionSizeNeeded()')
+    })
+
+    it('Should revert if dev and allowlist amounts are larger than collection size', async () => {
+      config.amountForDevs = 10
+      config.amountForAllowlist = 91
+      config.collectionSize = 100
+      await expect(deployLaunchpeg()).to.be.revertedWith('Launchpeg__LargerCollectionSizeNeeded()')
+    })
+
+    it('Should revert if max batch size is larger than collection size', async () => {
+      config.maxBatchSize = config.collectionSize * 2
+      await expect(deployLaunchpeg()).to.be.revertedWith('Launchpeg__InvalidMaxBatchSize()')
+    })
+  })
+
+  describe('Configure Launchpeg', () => {
+    it('Should allow owner to initialize fee configuration only once', async () => {
+      const feePercent = 200
+      const feeCollector = bob.address
+
+      await expect(launchpeg.connect(alice).initializeJoeFee(feePercent, feeCollector)).to.be.revertedWith(
+        'PendingOwnableUpgradeable__NotOwner()'
+      )
+
+      await launchpeg.initializeJoeFee(feePercent, feeCollector)
+      expect(await launchpeg.joeFeePercent()).to.eq(feePercent)
+      expect(await launchpeg.joeFeeCollector()).to.eq(feeCollector)
+
+      await expect(launchpeg.initializeJoeFee(feePercent, feeCollector)).to.be.revertedWith(
+        'Launchpeg__JoeFeeAlreadyInitialized()'
+      )
+    })
+
+    it('Should revert if fee percent is invalid', async () => {
+      const feePercent = 10001
+      const feeCollector = bob.address
+      await expect(launchpeg.initializeJoeFee(feePercent, feeCollector)).to.be.revertedWith(
+        'Launchpeg__InvalidPercent()'
+      )
+    })
+
+    it('Should revert if fee collector is zero address', async () => {
+      let feePercent = 100
+      let feeCollector = ethers.constants.AddressZero
+      await expect(launchpeg.initializeJoeFee(feePercent, feeCollector)).to.be.revertedWith(
+        'Launchpeg__InvalidJoeFeeCollector()'
+      )
+    })
+
+    it('Should allow owner to set royalty info', async () => {
+      const royaltyPercent = 500
+      const royaltyCollector = bob
+
+      await expect(
+        launchpeg.connect(alice).setRoyaltyInfo(royaltyCollector.address, royaltyPercent)
+      ).to.be.revertedWith('PendingOwnableUpgradeable__NotOwner()')
+
+      await launchpeg.setRoyaltyInfo(royaltyCollector.address, royaltyPercent)
+
+      const price = ethers.utils.parseEther('1')
+      expect((await launchpeg.royaltyInfo(1, price))[1]).to.eq(price.mul(royaltyPercent).div(10_000))
+    })
+
+    it('Should revert if royalty fee percent is invalid', async () => {
+      const royaltyPercent = 3_000
+      const royaltyCollector = bob
+      await expect(launchpeg.setRoyaltyInfo(royaltyCollector.address, royaltyPercent)).to.be.revertedWith(
+        'Launchpeg__InvalidRoyaltyInfo()'
+      )
+    })
+
+    it('Should allow owner to seed allowlist', async () => {
+      const addresses = [alice.address, bob.address]
+      const numNfts = [5, 10]
+
+      await expect(launchpeg.connect(alice).seedAllowlist(addresses, numNfts)).to.be.revertedWith(
+        'PendingOwnableUpgradeable__NotOwner()'
+      )
+
+      await launchpeg.seedAllowlist(addresses, numNfts)
+      expect(await launchpeg.allowlist(addresses[0])).to.eq(numNfts[0])
+      expect(await launchpeg.allowlist(addresses[0])).to.eq(numNfts[0])
+
+      await expect(launchpeg.seedAllowlist([alice.address], numNfts)).to.be.revertedWith(
+        'Launchpeg__WrongAddressesAndNumSlotsLength()'
+      )
+    })
+
+    it('Should allow owner to set base URI', async () => {
+      await expect(launchpeg.connect(alice).setBaseURI(config.baseTokenURI)).to.be.revertedWith(
+        'PendingOwnableUpgradeable__NotOwner()'
+      )
+
+      await launchpeg.setBaseURI(config.baseTokenURI)
+      expect(await launchpeg.baseURI()).to.eq(config.baseTokenURI)
+    })
+
+    it('Should allow owner to set unrevealed URI', async () => {
+      await expect(launchpeg.connect(alice).setUnrevealedURI(config.unrevealedTokenURI)).to.be.revertedWith(
+        'PendingOwnableUpgradeable__NotOwner()'
+      )
+
+      await launchpeg.setUnrevealedURI(config.unrevealedTokenURI)
+      expect(await launchpeg.unrevealedURI()).to.eq(config.unrevealedTokenURI)
+    })
+
+    it('Should allow owner to set batch reveal address', async () => {
+      await expect(launchpeg.connect(alice).setBatchReveal(batchReveal.address)).to.be.revertedWith(
+        'PendingOwnableUpgradeable__NotOwner()'
+      )
+
+      await launchpeg.setBatchReveal(batchReveal.address)
+    })
+  })
+
+  describe('Configure Launchpeg times', () => {
+    beforeEach(async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.NotStarted)
+    })
+
+    it('Should allow owner to set allowlist start time', async () => {
+      const newAllowlistStartTime = config.allowlistStartTime.sub(duration.minutes(30))
+      await expect(launchpeg.connect(projectOwner).setAllowlistStartTime(newAllowlistStartTime)).to.be.revertedWith(
+        'PendingOwnableUpgradeable__NotOwner()'
+      )
+
+      await launchpeg.setAllowlistStartTime(newAllowlistStartTime)
+      expect(await launchpeg.allowlistStartTime()).to.eq(newAllowlistStartTime)
+    })
+
+    it('Should revert if allowlist is before pre-mint or after public sale', async () => {
+      let invalidAllowlistStartTime = config.preMintStartTime.sub(duration.minutes(30))
+      await expect(launchpeg.setAllowlistStartTime(invalidAllowlistStartTime)).to.be.revertedWith(
+        'Launchpeg__AllowlistBeforePreMint()'
+      )
+
+      invalidAllowlistStartTime = config.publicSaleStartTime.add(duration.minutes(30))
+      await expect(launchpeg.setAllowlistStartTime(invalidAllowlistStartTime)).to.be.revertedWith(
+        'Launchpeg__PublicSaleBeforeAllowlist()'
+      )
+    })
+
+    it('Should allow owner to set public sale start time', async () => {
+      const newPublicSaleStartTime = config.publicSaleStartTime.sub(duration.minutes(30))
+      await expect(launchpeg.connect(projectOwner).setPublicSaleStartTime(newPublicSaleStartTime)).to.be.revertedWith(
+        'PendingOwnableUpgradeable__NotOwner()'
+      )
+
+      await launchpeg.setPublicSaleStartTime(newPublicSaleStartTime)
+      expect(await launchpeg.publicSaleStartTime()).to.eq(newPublicSaleStartTime)
+    })
+
+    it('Should revert if public sale start is before allowlist or after public sale end', async () => {
+      let invalidPublicSaleStartTime = config.allowlistStartTime.sub(duration.minutes(30))
+      await expect(launchpeg.setPublicSaleStartTime(invalidPublicSaleStartTime)).to.be.revertedWith(
+        'Launchpeg__PublicSaleBeforeAllowlist()'
+      )
+      invalidPublicSaleStartTime = config.publicSaleEndTime.add(duration.minutes(30))
+      await expect(launchpeg.setPublicSaleStartTime(invalidPublicSaleStartTime)).to.be.revertedWith(
+        'Launchpeg__PublicSaleEndBeforePublicSaleStart()'
+      )
+    })
+
+    it('Should allow owner to set public sale end time', async () => {
+      const newPublicSaleEndTime = config.publicSaleEndTime.sub(duration.minutes(30))
+      await expect(launchpeg.connect(projectOwner).setPublicSaleEndTime(newPublicSaleEndTime)).to.be.revertedWith(
+        'PendingOwnableUpgradeable__NotOwner()'
+      )
+
+      await launchpeg.setPublicSaleEndTime(newPublicSaleEndTime)
+      expect(await launchpeg.publicSaleEndTime()).to.eq(newPublicSaleEndTime)
+    })
+
+    it('Should revert if public sale end is before public sale start', async () => {
+      const invalidPublicSaleEndTime = config.publicSaleStartTime.sub(duration.minutes(30))
+      await expect(launchpeg.setPublicSaleEndTime(invalidPublicSaleEndTime)).to.be.revertedWith(
+        'Launchpeg__PublicSaleEndBeforePublicSaleStart()'
+      )
+    })
+
+    it('Should revert when setting phase times before phases are initialized', async () => {
+      const newAllowlistStartTime = config.allowlistStartTime.sub(duration.minutes(30))
+      const newPublicSaleStartTime = config.publicSaleStartTime.sub(duration.minutes(30))
+      const newPublicSaleEndTime = config.publicSaleEndTime.sub(duration.minutes(30))
+
+      await deployLaunchpeg()
+
+      await expect(launchpeg.setAllowlistStartTime(newAllowlistStartTime)).to.be.revertedWith(
+        'Launchpeg__NotInitialized()'
+      )
+      await expect(launchpeg.setPublicSaleStartTime(newPublicSaleStartTime)).to.be.revertedWith(
+        'Launchpeg__NotInitialized()'
+      )
+      await expect(launchpeg.setPublicSaleEndTime(newPublicSaleEndTime)).to.be.revertedWith(
+        'Launchpeg__NotInitialized()'
+      )
+    })
+
+    it('Should allow owner to set withdraw AVAX start time', async () => {
+      const blockTimestamp = await latest()
+      const newWithdrawAVAXStartTime = blockTimestamp.add(duration.hours(1))
+      await expect(
+        launchpeg.connect(projectOwner).setWithdrawAVAXStartTime(newWithdrawAVAXStartTime)
+      ).to.be.revertedWith('PendingOwnableUpgradeable__NotOwner()')
+
+      await launchpeg.setWithdrawAVAXStartTime(newWithdrawAVAXStartTime)
+      expect(await launchpeg.withdrawAVAXStartTime()).to.eq(newWithdrawAVAXStartTime)
+    })
+
+    it('Should revert if withdraw AVAX start time is before current block timestamp', async () => {
+      const blockTimestamp = await latest()
+      await expect(launchpeg.setWithdrawAVAXStartTime(blockTimestamp.sub(duration.minutes(1)))).to.be.revertedWith(
+        'Launchpeg__InvalidStartTime()'
+      )
+    })
+  })
+
+  describe('Project owner mint', () => {
+    it('Should allow dev to mint up to dev amount', async () => {
+      await expect(launchpeg.connect(alice).devMint(1)).to.be.revertedWith(
+        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
+      )
+
+      await launchpeg.connect(projectOwner).devMint(config.maxBatchSize)
+
+      // mint amount that is not a multiple of max batch size
+      await launchpeg.connect(projectOwner).devMint(config.amountForDevs - config.maxBatchSize - 1)
+      await launchpeg.connect(projectOwner).devMint(1)
+      expect(await launchpeg.balanceOf(projectOwner.address)).to.eq(config.amountForDevs)
+
+      await expect(launchpeg.connect(projectOwner).devMint(1)).to.be.revertedWith('Launchpeg__MaxSupplyForDevReached()')
+    })
+
+    it('Should revert if dev mint exceeds collection size', async () => {
+      config.collectionSize = 50
+      config.amountForDevs = 50
+      config.amountForAuction = 0
+      config.amountForAllowlist = 0
+      config.batchRevealSize = 10
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Allowlist)
+
+      await launchpeg.connect(projectOwner).devMint(config.amountForDevs)
+      await expect(launchpeg.connect(projectOwner).devMint(1)).to.be.revertedWith('Launchpeg__MaxSupplyReached()')
+    })
+
+    it('Should revert if dev mint exceeds dev amount', async () => {
+      config.collectionSize = 100
+      config.amountForDevs = 50
+      config.amountForAuction = 0
+      config.amountForAllowlist = 0
+      config.batchRevealSize = 10
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Allowlist)
+
+      await launchpeg.connect(projectOwner).devMint(config.amountForDevs)
+      await expect(launchpeg.connect(projectOwner).devMint(1)).to.be.revertedWith('Launchpeg__MaxSupplyForDevReached()')
+    })
+
+    it('Should allow user with project owner role to mint', async () => {
+      await launchpeg.connect(dev).grantRole(launchpeg.PROJECT_OWNER_ROLE(), alice.address)
+      await launchpeg.connect(alice).devMint(config.amountForDevs)
+      expect(await launchpeg.balanceOf(alice.address)).to.eq(config.amountForDevs)
+    })
+  })
+
+  describe('Pre-mint phase', () => {
+    let allowlistPrice: BigNumber
+
+    beforeEach(async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.PreMint)
+      await launchpeg.connect(dev).seedAllowlist([alice.address], [5])
+
+      const discount = config.startPrice.mul(config.allowlistDiscount).div(10000)
+      allowlistPrice = config.startPrice.sub(discount)
+    })
+
+    it('Should allow whitelisted user to pre-mint', async () => {
+      const quantity = 1
+      await launchpeg.connect(alice).preMint(quantity, { value: allowlistPrice.mul(quantity) })
+      expect(await launchpeg.amountMintedDuringPreMint()).to.eq(quantity)
+      expect(await launchpeg.numberMinted(alice.address)).to.eq(0)
+      expect(await launchpeg.numberMintedWithPreMint(alice.address)).to.eq(quantity)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity)
+
+      await expect(launchpeg.connect(bob).preMint(1, { value: allowlistPrice })).to.be.revertedWith(
+        'Launchpeg__NotEligibleForAllowlistMint'
+      )
+    })
+
+    it('Should receive allowlist price per NFT', async () => {
+      const quantity = 2
+      await launchpeg.connect(alice).preMint(quantity, { value: allowlistPrice.mul(quantity) })
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity)
+
+      await expect(launchpeg.connect(alice).preMint(1)).to.be.revertedWith('Launchpeg__NotEnoughAVAX(0)')
+    })
+
+    it('Should allow user to pre-mint up to allowlist allocation', async () => {
+      const allowlistQty = await launchpeg.allowlist(alice.address)
+      const quantity = 3
+      const remQuantity = allowlistQty - quantity
+      await launchpeg.connect(alice).preMint(quantity, { value: allowlistPrice.mul(quantity) })
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity)
+      expect(await launchpeg.allowlist(alice.address)).to.eq(remQuantity)
+
+      await expect(
+        launchpeg.connect(alice).preMint(remQuantity + 1, { value: allowlistPrice.mul(remQuantity + 1) })
+      ).to.be.revertedWith('Launchpeg__NotEligibleForAllowlistMint()')
+
+      await launchpeg.connect(alice).preMint(remQuantity, { value: allowlistPrice.mul(remQuantity) })
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity + remQuantity)
+    })
+
+    it('Should revert when pre-mint quantity is 0', async () => {
+      await expect(launchpeg.connect(alice).preMint(0)).to.be.revertedWith('Launchpeg__InvalidQuantity()')
+    })
+
+    it('Should not transfer pre-minted NFT to user', async () => {
+      await launchpeg.connect(alice).preMint(1, { value: allowlistPrice })
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(1)
+      expect(await launchpeg.balanceOf(alice.address)).to.eq(0)
+    })
+
+    it('Should allow users to pre-mint up to allowlist amount', async () => {
+      config = await getDefaultLaunchpegConfig()
+      config.amountForAllowlist = 5
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.PreMint)
+      await launchpeg.connect(dev).seedAllowlist([alice.address, bob.address], [5, 4])
+
+      const aliceQty = 4
+      const bobQty = 1
+      await launchpeg.connect(alice).preMint(aliceQty, { value: allowlistPrice.mul(aliceQty) })
+      await launchpeg.connect(bob).preMint(bobQty, { value: allowlistPrice.mul(bobQty) })
+
+      await expect(launchpeg.connect(bob).preMint(bobQty, { value: allowlistPrice.mul(bobQty) })).to.be.revertedWith(
+        'Launchpeg__MaxSupplyReached()'
+      )
+
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(aliceQty)
+      expect(await launchpeg.userAddressToPreMintAmount(bob.address)).to.eq(bobQty)
+      expect(await launchpeg.amountMintedDuringPreMint()).to.eq(aliceQty + bobQty)
+    })
+
+    it('Should not allow batch mint during pre-mint phase', async () => {
+      await launchpeg.connect(alice).preMint(1, { value: allowlistPrice })
+      await expect(launchpeg.connect(bob).batchMintPreMintedNFTs(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
+    })
+  })
+
+  describe('Allowlist phase', async () => {
+    let allowlistPrice: BigNumber
+
+    beforeEach(async () => {
+      const discount = config.startPrice.mul(config.allowlistDiscount).div(10000)
+      allowlistPrice = config.startPrice.sub(discount)
+    })
+
+    it('Should allow whitelisted user to pre-mint and allowlist mint up to allowlist amount', async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.PreMint)
+      await launchpeg.connect(dev).seedAllowlist([alice.address], [10])
+
+      // Alice pre-mints
+      const preMintQty = 5
+      const allowlistMintQty = 5
+      await launchpeg.connect(alice).preMint(preMintQty, { value: allowlistPrice.mul(preMintQty) })
+
+      // Advance to allowlist phase
+      const blockTimestamp = await latest()
+      await advanceTimeAndBlock(duration.seconds(config.allowlistStartTime.sub(blockTimestamp).toNumber()))
+      expect(await launchpeg.allowlist(alice.address)).to.eq(allowlistMintQty)
+
+      // Alice allowlist mints
+      await launchpeg.connect(alice).allowlistMint(allowlistMintQty, { value: allowlistPrice.mul(allowlistMintQty) })
+      expect(await launchpeg.allowlist(alice.address)).to.eq(0)
+      expect(await launchpeg.numberMinted(alice.address)).to.eq(allowlistMintQty)
+      expect(await launchpeg.numberMintedWithPreMint(alice.address)).to.eq(allowlistMintQty + preMintQty)
+
+      await expect(launchpeg.connect(alice).allowlistMint(1, { value: allowlistPrice })).to.be.revertedWith(
+        'Launchpeg__NotEligibleForAllowlistMint()'
+      )
+    })
+
+    it('Should allow any user to batch mint', async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.PreMint)
+      await launchpeg.connect(dev).seedAllowlist([alice.address, bob.address], [10, 5])
+
+      // Alice and Bob pre-mint
+      const alicePreMintQty = 10
+      const bobPreMintQty = 5
+      await launchpeg.connect(alice).preMint(alicePreMintQty, { value: allowlistPrice.mul(alicePreMintQty) })
+      await launchpeg.connect(bob).preMint(bobPreMintQty, { value: allowlistPrice.mul(alicePreMintQty) })
+
+      // Advance to allowlist phase
+      const blockTimestamp = await latest()
+      await advanceTimeAndBlock(duration.seconds(config.allowlistStartTime.sub(blockTimestamp).toNumber()))
+      expect(await launchpeg.balanceOf(alice.address)).to.eq(0)
+      expect(await launchpeg.balanceOf(bob.address)).to.eq(0)
+
+      // Bob batch mints
+      await launchpeg.connect(bob).batchMintPreMintedNFTs(5)
+      expect(await launchpeg.balanceOf(alice.address)).to.eq(5)
+      expect(await launchpeg.balanceOf(bob.address)).to.eq(0)
+
+      // Alice batch mints (more than available in queue)
+      await launchpeg.connect(alice).batchMintPreMintedNFTs(20)
+      expect(await launchpeg.balanceOf(alice.address)).to.eq(10)
+      expect(await launchpeg.balanceOf(bob.address)).to.eq(5)
+      expect(await launchpeg.amountBatchMinted()).to.eq(15)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(0)
+      expect(await launchpeg.userAddressToPreMintAmount(bob.address)).to.eq(0)
+      expect(await launchpeg.numberMinted(bob.address)).to.eq(5)
+      expect(await launchpeg.numberMintedWithPreMint(bob.address)).to.eq(5)
+
+      await expect(launchpeg.batchMintPreMintedNFTs(5)).to.be.revertedWith('Launchpeg__MaxSupplyForBatchMintReached()')
+    })
+
+    it('Should revert when there are no NFTs to batch mint', async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Allowlist)
+      await expect(launchpeg.batchMintPreMintedNFTs(0)).to.be.revertedWith('Launchpeg__InvalidQuantity()')
+      await expect(launchpeg.batchMintPreMintedNFTs(5)).to.be.revertedWith('Launchpeg__MaxSupplyForBatchMintReached()')
+    })
+  })
+
+  describe('Public sale phase', () => {
+    let allowlistPrice: BigNumber
+
+    beforeEach(async () => {
+      const discount = config.startPrice.mul(config.allowlistDiscount).div(10000)
+      allowlistPrice = config.startPrice.sub(discount)
+    })
+
+    it('Should allow any user to batch mint', async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.PreMint)
+      await launchpeg.connect(dev).seedAllowlist([alice.address], [5])
+
+      // Alice pre-mints
+      const preMintQty = 2
+      await launchpeg.connect(alice).preMint(preMintQty, { value: allowlistPrice.mul(preMintQty) })
+
+      // Advance to public sale phase
+      const blockTimestamp = await latest()
+      await advanceTimeAndBlock(duration.seconds(config.publicSaleStartTime.sub(blockTimestamp).toNumber()))
+      expect(await launchpeg.balanceOf(alice.address)).to.eq(0)
+
+      // Bob batch mints
+      await launchpeg.connect(bob).batchMintPreMintedNFTs(preMintQty)
+      expect(await launchpeg.balanceOf(alice.address)).to.eq(preMintQty)
+      expect(await launchpeg.amountBatchMinted()).to.eq(preMintQty)
+      expect(await launchpeg.userAddressToPreMintAmount(alice.address)).to.eq(0)
+      expect(await launchpeg.numberMinted(alice.address)).to.eq(preMintQty)
+      expect(await launchpeg.numberMintedWithPreMint(alice.address)).to.eq(preMintQty)
+
+      await expect(launchpeg.batchMintPreMintedNFTs(5)).to.be.revertedWith('Launchpeg__MaxSupplyForBatchMintReached()')
+    })
+
+    it('Should not allow batch mint after public sale', async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Ended)
+      await expect(launchpeg.batchMintPreMintedNFTs(5)).to.be.revertedWith('Launchpeg__WrongPhase()')
+    })
+  })
+
+  describe('Funds flow', () => {
+    let publicSalePrice: BigNumber
+
+    beforeEach(async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.PublicSale)
+      const discount = config.startPrice.mul(config.publicSaleDiscount).div(10000)
+      publicSalePrice = config.startPrice.sub(discount)
+    })
+
+    it('Should allow owner to withdraw funds', async () => {
+      await expect(launchpeg.connect(alice).withdrawAVAX(alice.address)).to.be.revertedWith(
+        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
+      )
+
+      await launchpeg.connect(alice).publicSaleMint(5, { value: publicSalePrice.mul(5) })
+      await launchpeg.connect(bob).publicSaleMint(4, { value: publicSalePrice.mul(4) })
+
+      const initialDevBalance = await dev.getBalance()
+      await launchpeg.connect(dev).withdrawAVAX(dev.address)
+      expect(await dev.getBalance()).to.be.closeTo(
+        initialDevBalance.add(publicSalePrice.mul(9)),
+        ethers.utils.parseEther('0.01')
+      )
+    })
+
+    it('Should allow project owner to withdraw funds', async () => {
+      await launchpeg.connect(alice).publicSaleMint(5, { value: publicSalePrice.mul(5) })
+      await launchpeg.connect(bob).publicSaleMint(4, { value: publicSalePrice.mul(4) })
+
+      const initialBalance = await projectOwner.getBalance()
+      await launchpeg.connect(projectOwner).withdrawAVAX(projectOwner.address)
+      expect(await projectOwner.getBalance()).to.be.closeTo(
+        initialBalance.add(publicSalePrice.mul(9)),
+        ethers.utils.parseEther('0.01')
+      )
+    })
+
+    it('Should revert if project owner withdraws funds before withdraw start time', async () => {
+      const blockTimestamp = await latest()
+      await launchpeg.setWithdrawAVAXStartTime(blockTimestamp.add(duration.hours(1)))
+
+      await expect(launchpeg.connect(projectOwner).withdrawAVAX(projectOwner.address)).to.be.revertedWith(
+        'Launchpeg__WithdrawAVAXNotAvailable()'
+      )
+    })
+
+    it('Should revert if project owner withdraws funds before withdraw start time is initialized', async () => {
+      await deployLaunchpeg()
+      await expect(launchpeg.connect(projectOwner).withdrawAVAX(projectOwner.address)).to.be.revertedWith(
+        'Launchpeg__WithdrawAVAXNotAvailable()'
+      )
+    })
+
+    it('Should send fee correctly to fee collector address', async () => {
+      const feePercent = 200
+      const feeCollector = bob
+      await launchpeg.initializeJoeFee(feePercent, feeCollector.address)
+
+      const total = publicSalePrice.mul(5)
+      await launchpeg.connect(alice).publicSaleMint(5, { value: total })
+
+      const fee = total.mul(feePercent).div(10000)
+      const initialDevBalance = await dev.getBalance()
+      const initialFeeCollectorBalance = await feeCollector.getBalance()
+      await launchpeg.connect(dev).withdrawAVAX(dev.address)
+      expect(await dev.getBalance()).to.be.closeTo(
+        initialDevBalance.add(total.sub(fee)),
+        ethers.utils.parseEther('0.01')
+      )
+      expect(await feeCollector.getBalance()).to.eq(initialFeeCollectorBalance.add(fee))
+    })
+  })
+
+  describe('Batch reveal disabled', () => {
+    beforeEach(async () => {
+      await launchpeg.setBatchReveal(ethers.constants.AddressZero)
+    })
+
+    it('Should reveal NFTs immediately', async () => {
+      const tokenId = 0
+      const expTokenURI = `${config.baseTokenURI}${tokenId}`
+      config.batchRevealSize = 0
+      await launchpeg.setBaseURI(config.baseTokenURI)
+      expect(await launchpeg.tokenURI(tokenId)).to.eq(expTokenURI)
+    })
+
+    it('Should revert when user reveals next batch', async () => {
+      await expect(launchpeg.revealNextBatch()).to.be.revertedWith('Launchpeg__BatchRevealDisabled()')
+    })
+
+    it('Should return false when user checks if there is a batch to reveal', async () => {
+      const hasBatchToReveal = await launchpeg.hasBatchToReveal()
+      expect(hasBatchToReveal[0]).to.eq(false)
+      expect(hasBatchToReveal[1]).to.eq(0)
+    })
+  })
+
+  describe('Batch reveal during mint', () => {
+    it('Should not reveal NFTs initially', async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.NotStarted)
+      expect(await launchpeg.tokenURI(0)).to.eq(config.unrevealedTokenURI)
+    })
+
+    it('Should reveal first NFTs gradually', async () => {
+      config.collectionSize = 50
+      config.amountForDevs = 50
+      config.amountForAuction = 0
+      config.amountForAllowlist = 0
+      config.batchRevealSize = 10
+      config.batchRevealStart = BigNumber.from(0)
+      config.batchRevealInterval = BigNumber.from(0)
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Allowlist)
+
+      // Project owner mints 1st batch
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+
+      expect((await launchpeg.hasBatchToReveal())[0]).to.eq(true)
+      await launchpeg.connect(alice).revealNextBatch()
+      expect((await launchpeg.hasBatchToReveal())[0]).to.eq(false)
+      expect(await launchpeg.tokenURI(0)).to.contains(config.baseTokenURI)
+      expect(await launchpeg.tokenURI(config.batchRevealSize)).to.eq(config.unrevealedTokenURI)
+
+      // Project owner mints 2nd batch
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+
+      expect((await launchpeg.hasBatchToReveal())[1]).to.eq(BigNumber.from(1))
+      await launchpeg.connect(bob).revealNextBatch()
+      expect(await launchpeg.tokenURI(2 * config.batchRevealSize - 1)).to.contains(config.baseTokenURI)
+      expect(await launchpeg.tokenURI(2 * config.batchRevealSize + 1)).to.eq(config.unrevealedTokenURI)
+
+      // Mint the rest of the collection
+      for (let i = 0; i < 3; i++) {
+        await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+        await launchpeg.connect(bob).revealNextBatch()
+      }
+      expect(await launchpeg.tokenURI(config.collectionSize - 1)).to.contains(config.baseTokenURI)
+    })
+
+    it('Should revert when user reveals next batch too early', async () => {
+      config.collectionSize = 50
+      config.amountForDevs = 50
+      config.amountForAuction = 0
+      config.amountForAllowlist = 0
+      config.batchRevealSize = 10
+      config.batchRevealStart = BigNumber.from(0)
+      config.batchRevealInterval = BigNumber.from(0)
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Allowlist)
+
+      await expect(launchpeg.connect(alice).revealNextBatch()).to.be.revertedWith(
+        'Launchpeg__RevealNextBatchNotAvailable'
+      )
+
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+      await launchpeg.connect(bob).revealNextBatch()
+      await expect(launchpeg.connect(alice).revealNextBatch()).to.be.revertedWith(
+        'Launchpeg__RevealNextBatchNotAvailable'
+      )
+    })
+  })
+
+  describe('Batch reveal after sale', () => {
+    it('Should not reveal first NFTs during sale (before reveal start time)', async () => {
+      config.collectionSize = 50
+      config.amountForDevs = 50
+      config.amountForAuction = 0
+      config.amountForAllowlist = 0
+      config.batchRevealSize = 10
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Allowlist)
+
+      // Project owner mints 1st batch
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+
+      expect(await launchpeg.tokenURI(0)).to.eq(config.unrevealedTokenURI)
+      await expect(launchpeg.connect(alice).revealNextBatch()).to.be.revertedWith(
+        'Launchpeg__RevealNextBatchNotAvailable'
+      )
+
+      // Project owner mints 2nd batch
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+
+      expect(await launchpeg.tokenURI(2 * config.batchRevealSize - 1)).to.eq(config.unrevealedTokenURI)
+      await expect(launchpeg.connect(alice).revealNextBatch()).to.be.revertedWith(
+        'Launchpeg__RevealNextBatchNotAvailable'
+      )
+    })
+
+    it('Should gradually reveal NFTs after reveal start time', async () => {
+      config.collectionSize = 50
+      config.amountForDevs = 50
+      config.amountForAuction = 0
+      config.amountForAllowlist = 0
+      config.batchRevealSize = 10
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Reveal)
+
+      await launchpeg.connect(projectOwner).devMint(3 * config.batchRevealSize)
+
+      await launchpeg.connect(alice).revealNextBatch()
+      expect(await launchpeg.tokenURI(0)).to.contains(config.baseTokenURI)
+      expect(await launchpeg.tokenURI(config.batchRevealSize)).to.eq(config.unrevealedTokenURI)
+
+      // Too early to reveal next batch
+      await expect(launchpeg.connect(bob).revealNextBatch()).to.be.revertedWith(
+        'Launchpeg__RevealNextBatchNotAvailable'
+      )
+      await advanceTimeAndBlock(config.batchRevealInterval)
+
+      await launchpeg.connect(bob).revealNextBatch()
+      expect(await launchpeg.tokenURI(2 * config.batchRevealSize - 1)).to.contains(config.baseTokenURI)
+      expect(await launchpeg.tokenURI(2 * config.batchRevealSize + 1)).to.eq(config.unrevealedTokenURI)
+    })
+  })
+
+  describe('Pause Launchpeg methods', () => {
+    let PAUSER_ROLE: Bytes
+    let UNPAUSER_ROLE: Bytes
+
+    beforeEach(async () => {
+      PAUSER_ROLE = await launchpeg.PAUSER_ROLE()
+      UNPAUSER_ROLE = await launchpeg.UNPAUSER_ROLE()
+    })
+
+    it('Should allow owner to pause and unpause', async () => {
+      await launchpeg.pause()
+      expect(await launchpeg.paused()).to.eq(true)
+
+      await launchpeg.unpause()
+      expect(await launchpeg.paused()).to.eq(false)
+    })
+
+    it('Should allow user with PAUSER_ROLE to pause and UNPAUSER_ROLE to unpause', async () => {
+      await expect(launchpeg.connect(alice).pause()).to.be.revertedWith(
+        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
+      )
+      await launchpeg.grantRole(PAUSER_ROLE, alice.address)
+      await launchpeg.connect(alice).pause()
+      expect(await launchpeg.paused()).to.eq(true)
+
+      await expect(launchpeg.connect(alice).unpause()).to.be.revertedWith(
+        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
+      )
+      await launchpeg.grantRole(UNPAUSER_ROLE, alice.address)
+      await launchpeg.connect(alice).unpause()
+      expect(await launchpeg.paused()).to.eq(false)
+    })
+
+    it('Should allow owner to grant and revoke PAUSER_ROLE and UNPAUSER_ROLE', async () => {
+      await launchpeg.grantRole(PAUSER_ROLE, alice.address)
+      await launchpeg.connect(alice).pause()
+      await launchpeg.revokeRole(PAUSER_ROLE, alice.address)
+      await expect(launchpeg.connect(alice).pause()).to.be.revertedWith(
+        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
+      )
+
+      await launchpeg.grantRole(UNPAUSER_ROLE, alice.address)
+      await launchpeg.connect(alice).unpause()
+      await launchpeg.revokeRole(UNPAUSER_ROLE, alice.address)
+      await expect(launchpeg.connect(alice).unpause()).to.be.revertedWith(
+        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
+      )
+    })
+
+    it('Should not allow non-owner to grant PAUSER_ROLE and UNPAUSER_ROLE', async () => {
+      await expect(launchpeg.connect(projectOwner).grantRole(PAUSER_ROLE, alice.address)).to.be.revertedWith(
+        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
+      )
+      await expect(launchpeg.connect(projectOwner).grantRole(UNPAUSER_ROLE, alice.address)).to.be.revertedWith(
+        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
+      )
+    })
+
+    it('Should not allow non-owner to revoke PAUSER_ROLE and UNPAUSER_ROLE', async () => {
+      await launchpeg.grantRole(PAUSER_ROLE, alice.address)
+      await expect(launchpeg.connect(bob).revokeRole(PAUSER_ROLE, alice.address)).to.be.revertedWith(
+        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
+      )
+      await launchpeg.connect(alice).pause()
+
+      await launchpeg.grantRole(UNPAUSER_ROLE, alice.address)
+      await expect(launchpeg.connect(bob).revokeRole(UNPAUSER_ROLE, alice.address)).to.be.revertedWith(
+        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
+      )
+      await launchpeg.connect(alice).unpause()
+    })
+
+    it('Should allow owner or pauser to pause mint methods', async () => {
+      await launchpeg.pause()
+      await expect(launchpeg.connect(dev).devMint(1)).to.be.revertedWith('Pausable: paused')
+
+      await launchpeg.unpause()
+      await launchpeg.connect(dev).devMint(1)
+    })
+
+    it('Should allow owner or pauser to pause funds withdrawal', async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.PublicSale)
+      await launchpeg.pause()
+      await expect(launchpeg.connect(projectOwner).withdrawAVAX(alice.address)).to.be.revertedWith('Pausable: paused')
+
+      await launchpeg.unpause()
+      await launchpeg.connect(projectOwner).withdrawAVAX(alice.address)
+    })
+
+    it('Should allow owner or pauser to pause batch reveal', async () => {
+      config.collectionSize = 50
+      config.amountForDevs = 10
+      config.amountForAuction = 0
+      config.amountForAllowlist = 0
+      config.batchRevealSize = 10
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Reveal)
+      await launchpeg.devMint(10)
+
+      await launchpeg.pause()
+      await expect(launchpeg.connect(alice).revealNextBatch()).to.be.revertedWith('Pausable: paused')
+
+      await launchpeg.unpause()
+      await launchpeg.connect(alice).revealNextBatch()
+    })
+  })
+
+  after(async () => {
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [],
+    })
+  })
+})

--- a/test/BatchReveal.test.ts
+++ b/test/BatchReveal.test.ts
@@ -1,0 +1,349 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import { ContractFactory, Contract, BigNumber, Bytes } from 'ethers'
+import { config as hardhatConfig, ethers, network } from 'hardhat'
+import { initializePhasesLaunchpeg, getDefaultLaunchpegConfig, Phase, LaunchpegConfig } from './utils/helpers'
+import { advanceTimeAndBlock, latest, duration } from './utils/time'
+
+describe('BatchReveal', () => {
+  let launchpegCF: ContractFactory
+  let batchRevealCF: ContractFactory
+  let coordinatorMockCF: ContractFactory
+  let launchpeg: Contract
+  let batchReveal: Contract
+  let coordinatorMock: Contract
+
+  let config: LaunchpegConfig
+
+  let signers: SignerWithAddress[]
+  let dev: SignerWithAddress
+  let alice: SignerWithAddress
+  let bob: SignerWithAddress
+  let projectOwner: SignerWithAddress
+  let royaltyReceiver: SignerWithAddress
+
+  before(async () => {
+    launchpegCF = await ethers.getContractFactory('Launchpeg')
+    batchRevealCF = await ethers.getContractFactory('BatchReveal')
+    coordinatorMockCF = await ethers.getContractFactory('VRFCoordinatorV2Mock')
+
+    signers = await ethers.getSigners()
+    dev = signers[0]
+    alice = signers[1]
+    bob = signers[2]
+    projectOwner = signers[3]
+    royaltyReceiver = signers[4]
+
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [
+        {
+          live: false,
+          saveDeployments: true,
+          tags: ['test', 'local'],
+        },
+      ],
+    })
+  })
+
+  const deployBatchReveal = async () => {
+    batchReveal = await batchRevealCF.deploy()
+    await batchReveal.initialize()
+  }
+
+  const deployLaunchpeg = async (enableBatchReveal: boolean = true) => {
+    launchpeg = await launchpegCF.deploy()
+    await launchpeg.initialize(
+      'JoePEG',
+      'JOEPEG',
+      projectOwner.address,
+      royaltyReceiver.address,
+      config.maxBatchSize,
+      config.collectionSize,
+      config.amountForAuction,
+      config.amountForAllowlist,
+      config.amountForDevs
+    )
+    if (enableBatchReveal) {
+      await batchReveal.configure(
+        launchpeg.address,
+        config.batchRevealSize,
+        config.batchRevealStart,
+        config.batchRevealInterval
+      )
+      await launchpeg.setBatchReveal(batchReveal.address)
+    }
+  }
+
+  beforeEach(async () => {
+    config = await getDefaultLaunchpegConfig()
+    await deployBatchReveal()
+    await deployLaunchpeg()
+  })
+
+  describe('Initialize BatchReveal', () => {
+    it('Should allow owner to initialize only once', async () => {
+      await expect(batchReveal.initialize()).to.be.revertedWith('Initializable: contract is already initialized')
+    })
+  })
+
+  describe('Configure BatchReveal', () => {
+    it('Should allow owner to configure batch reveal', async () => {
+      await expect(
+        batchReveal
+          .connect(alice)
+          .configure(launchpeg.address, config.batchRevealSize, config.batchRevealStart, config.batchRevealInterval)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
+
+      const batchRevealConfig = await batchReveal.launchpegToConfig(launchpeg.address)
+      expect(batchRevealConfig.collectionSize).to.eq(config.collectionSize)
+      expect(batchRevealConfig.intCollectionSize).to.eq(config.collectionSize)
+      expect(batchRevealConfig.revealBatchSize).to.eq(config.batchRevealSize)
+      expect(batchRevealConfig.revealStartTime).to.eq(config.batchRevealStart)
+      expect(batchRevealConfig.revealInterval).to.eq(config.batchRevealInterval)
+    })
+
+    it('Should revert when owner configures after batch reveal starts', async () => {
+      config.batchRevealSize = 10
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.Reveal)
+
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+      await launchpeg.connect(alice).revealNextBatch()
+      await expect(
+        batchReveal.configure(
+          launchpeg.address,
+          config.batchRevealSize,
+          config.batchRevealStart,
+          config.batchRevealInterval
+        )
+      ).to.be.revertedWith('Launchpeg__BatchRevealStarted()')
+
+      await expect(batchReveal.setRevealBatchSize(launchpeg.address, config.batchRevealSize)).to.be.revertedWith(
+        'Launchpeg__BatchRevealStarted()'
+      )
+
+      await expect(batchReveal.setRevealStartTime(launchpeg.address, config.batchRevealStart)).to.be.revertedWith(
+        'Launchpeg__BatchRevealStarted()'
+      )
+
+      await expect(batchReveal.setRevealInterval(launchpeg.address, config.batchRevealInterval)).to.be.revertedWith(
+        'Launchpeg__BatchRevealStarted()'
+      )
+    })
+
+    it('Should allow owner to set reveal batch size', async () => {
+      const revealBatchSize = 10
+
+      await expect(
+        batchReveal.connect(alice).setRevealBatchSize(launchpeg.address, revealBatchSize)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
+
+      batchReveal.setRevealBatchSize(launchpeg.address, revealBatchSize)
+
+      const batchRevealConfig = await batchReveal.launchpegToConfig(launchpeg.address)
+      expect(batchRevealConfig.revealBatchSize).to.eq(revealBatchSize)
+    })
+
+    it('Should revert if reveal batch size is invalid', async () => {
+      await expect(batchReveal.setRevealBatchSize(launchpeg.address, 0)).to.be.revertedWith(
+        'Launchpeg__InvalidBatchRevealSize()'
+      )
+
+      await expect(batchReveal.setRevealBatchSize(launchpeg.address, config.batchRevealSize + 1)).to.be.revertedWith(
+        'Launchpeg__InvalidBatchRevealSize()'
+      )
+
+      await expect(batchReveal.setRevealBatchSize(launchpeg.address, config.collectionSize + 1)).to.be.revertedWith(
+        'Launchpeg__InvalidBatchRevealSize()'
+      )
+    })
+
+    it('Should allow owner to set reveal start time', async () => {
+      const revealStartTime = config.batchRevealStart.sub(duration.minutes(10))
+
+      await expect(
+        batchReveal.connect(alice).setRevealStartTime(launchpeg.address, revealStartTime)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
+
+      batchReveal.setRevealStartTime(launchpeg.address, revealStartTime)
+
+      const batchRevealConfig = await batchReveal.launchpegToConfig(launchpeg.address)
+      expect(batchRevealConfig.revealStartTime).to.eq(revealStartTime)
+    })
+
+    it('Should revert if reveal start time is invalid', async () => {
+      const batchRevealStart = config.batchRevealStart.add(8_640_000)
+      await expect(batchReveal.setRevealStartTime(launchpeg.address, batchRevealStart)).to.be.revertedWith(
+        'Launchpeg__InvalidRevealDates()'
+      )
+    })
+
+    it('Should allow owner to set reveal interval', async () => {
+      const revealInterval = config.batchRevealInterval.sub(duration.minutes(10))
+
+      await expect(batchReveal.connect(alice).setRevealInterval(launchpeg.address, revealInterval)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+
+      batchReveal.setRevealInterval(launchpeg.address, revealInterval)
+
+      const batchRevealConfig = await batchReveal.launchpegToConfig(launchpeg.address)
+      expect(batchRevealConfig.revealInterval).to.eq(revealInterval)
+    })
+
+    it('Should revert if reveal interval is invalid', async () => {
+      const revealInterval = 864_001
+      await expect(batchReveal.setRevealInterval(launchpeg.address, revealInterval)).to.be.revertedWith(
+        'Launchpeg__InvalidRevealDates()'
+      )
+    })
+
+    it('Should revert when setting batch reveal config if batch reveal is not initialized', async () => {
+      await deployLaunchpeg(false)
+      await expect(batchReveal.setRevealBatchSize(launchpeg.address, config.batchRevealSize)).to.be.revertedWith(
+        'Launchpeg__BatchRevealNotInitialized()'
+      )
+
+      await expect(batchReveal.setRevealStartTime(launchpeg.address, config.batchRevealStart)).to.be.revertedWith(
+        'Launchpeg__BatchRevealNotInitialized()'
+      )
+
+      await expect(batchReveal.setRevealInterval(launchpeg.address, config.batchRevealInterval)).to.be.revertedWith(
+        'Launchpeg__BatchRevealNotInitialized()'
+      )
+    })
+  })
+
+  describe('VRF', () => {
+    const setVRF = async () => {
+      await batchReveal.setVRF(coordinatorMock.address, ethers.utils.formatBytes32String('Oxff'), 1, 200_000)
+    }
+
+    beforeEach(async () => {
+      coordinatorMock = await coordinatorMockCF.deploy(1, 1)
+      await coordinatorMock.createSubscription()
+      await coordinatorMock.fundSubscription(1, 1_000_000)
+      await coordinatorMock.addKeyHash(ethers.utils.formatBytes32String('Oxff'))
+
+      config.collectionSize = 50
+      config.amountForDevs = 50
+      config.amountForAuction = 0
+      config.amountForAllowlist = 0
+      config.batchRevealSize = 10
+      config.batchRevealStart = BigNumber.from(0)
+      config.batchRevealInterval = BigNumber.from(0)
+      await deployLaunchpeg()
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.DutchAuction)
+      await coordinatorMock.addConsumer(0, batchReveal.address)
+      await setVRF()
+      await launchpeg.setBaseURI('base/')
+      await launchpeg.setUnrevealedURI('unrevealed')
+    })
+
+    it('Initialisation checks', async () => {
+      await expect(
+        batchReveal.setVRF(ethers.constants.AddressZero, ethers.utils.formatBytes32String('Oxff'), 1, 200_000)
+      ).to.be.revertedWith('Launchpeg__InvalidCoordinator()')
+
+      await expect(
+        batchReveal.setVRF(coordinatorMock.address, ethers.utils.formatBytes32String('Oxff'), 1, 0)
+      ).to.be.revertedWith('Launchpeg__InvalidCallbackGasLimit()')
+
+      await expect(
+        batchReveal.setVRF(coordinatorMock.address, ethers.utils.formatBytes32String('Ox00'), 1, 200_000)
+      ).to.be.revertedWith('Launchpeg__InvalidKeyHash()')
+
+      await coordinatorMock.removeConsumer(0, ethers.constants.AddressZero)
+      await coordinatorMock.addConsumer(0, launchpeg.address)
+      await expect(
+        batchReveal.setVRF(coordinatorMock.address, ethers.utils.formatBytes32String('Oxff'), 1, 200_000)
+      ).to.be.revertedWith('Launchpeg__IsNotInTheConsumerList()')
+    })
+
+    it('Should draw correctly', async () => {
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+      await launchpeg.revealNextBatch()
+      // URIs are not revealed before Chainlink's coordinator response
+      expect(await launchpeg.tokenURI(3)).to.eq('unrevealed')
+
+      await coordinatorMock.fulfillRandomWords(1, batchReveal.address)
+      const token3URI = await launchpeg.tokenURI(3)
+      expect(token3URI).to.contains('base')
+      expect(await launchpeg.tokenURI(3 + config.batchRevealSize)).to.eq('unrevealed')
+
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+      await launchpeg.revealNextBatch()
+      await coordinatorMock.fulfillRandomWords(2, batchReveal.address)
+      expect(await launchpeg.tokenURI(3)).to.eq(token3URI)
+      expect(await launchpeg.tokenURI(3 + config.batchRevealSize)).to.contains('base')
+      expect(await launchpeg.tokenURI(3 + 2 * config.batchRevealSize)).to.eq('unrevealed')
+    })
+
+    it('Should be able to force reveal if VRF fails', async () => {
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+      await launchpeg.revealNextBatch()
+      expect(await launchpeg.tokenURI(3)).to.eq('unrevealed')
+
+      await batchReveal.connect(dev).forceReveal(launchpeg.address)
+      const token3URI = await launchpeg.tokenURI(3)
+      expect(token3URI).to.contains('base')
+      expect(await launchpeg.tokenURI(3 + config.batchRevealSize)).to.eq('unrevealed')
+
+      // Coordinator's response coming too late
+      await coordinatorMock.fulfillRandomWords(1, launchpeg.address)
+      // Doesn't reveal anything
+      expect(await launchpeg.tokenURI(3 + config.batchRevealSize)).to.eq('unrevealed')
+      expect(await launchpeg.tokenURI(3)).to.eq(token3URI)
+    })
+
+    it('Should revert when fulfilling random words if collection has been force revealed', async () => {
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+      await launchpeg.revealNextBatch()
+
+      await batchReveal.forceReveal(launchpeg.address)
+      await coordinatorMock.fulfillRandomWords(1, batchReveal.address)
+    })
+
+    it('Should not be able to spam VRF requests', async () => {
+      await launchpeg.connect(projectOwner).devMint(config.batchRevealSize)
+      await launchpeg.revealNextBatch()
+      await expect(launchpeg.revealNextBatch()).to.be.revertedWith('Launchpeg__RevealNextBatchNotAvailable()')
+    })
+  })
+
+  describe('Reveal batch', () => {
+    it('Should allow owner to force reveal if the collection does not sell out', async () => {
+      await initializePhasesLaunchpeg(launchpeg, config, Phase.PublicSale)
+
+      // No one bought the collection :(
+      await launchpeg.connect(projectOwner).devMint(config.amountForDevs)
+
+      // Should fail since not enough tokens have been minted for a reveal
+      await expect(launchpeg.connect(bob).revealNextBatch()).to.be.revertedWith(
+        'Launchpeg__RevealNextBatchNotAvailable()'
+      )
+
+      await expect(batchReveal.connect(bob).forceReveal(launchpeg.address)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+
+      await batchReveal.connect(dev).forceReveal(launchpeg.address)
+
+      // Batch 1 is revealed
+      expect(await launchpeg.tokenURI(0)).to.contains(config.baseTokenURI)
+      expect(await launchpeg.tokenURI(config.batchRevealSize)).to.eq(config.unrevealedTokenURI)
+    })
+
+    it('Should revert if revealNextBatch() is not called by Launchpeg contract', async () => {
+      await expect(batchReveal.revealNextBatch(launchpeg.address, 123)).to.be.revertedWith('Launchpeg__Unauthorized()')
+    })
+  })
+
+  after(async () => {
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [],
+    })
+  })
+})

--- a/test/FlatLaunchpeg.test.ts
+++ b/test/FlatLaunchpeg.test.ts
@@ -20,9 +20,6 @@ describe('FlatLaunchpeg', () => {
   let projectOwner: SignerWithAddress
   let royaltyReceiver: SignerWithAddress
 
-  let PAUSER_ROLE: Bytes
-  let UNPAUSER_ROLE: Bytes
-
   before(async () => {
     flatLaunchpegCF = await ethers.getContractFactory('FlatLaunchpeg')
     batchRevealCF = await ethers.getContractFactory('BatchReveal')
@@ -73,129 +70,130 @@ describe('FlatLaunchpeg', () => {
   }
 
   beforeEach(async () => {
-    config = { ...(await getDefaultLaunchpegConfig()) }
+    config = await getDefaultLaunchpegConfig()
     await deployBatchReveal()
     await deployFlatLaunchpeg()
   })
 
-  describe('Initialization', () => {
-    it('Should not allow collection size to be 0', async () => {
-      config.collectionSize = 0
-      config.batchRevealSize = 0
-      await expect(deployFlatLaunchpeg()).to.be.revertedWith('Launchpeg__LargerCollectionSizeNeeded()')
+  describe('Initialize FlatLaunchpeg', () => {
+    it('Should allow owner to initialize only once', async () => {
+      await expect(
+        flatLaunchpeg.initialize(
+          'JoePEG',
+          'JOEPEG',
+          projectOwner.address,
+          royaltyReceiver.address,
+          config.maxBatchSize,
+          config.collectionSize,
+          config.amountForDevs,
+          config.amountForAllowlist
+        )
+      ).to.be.revertedWith('Initializable: contract is already initialized')
     })
+  })
 
-    it('Phases can be updated', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)
+  describe('Initialize phases', () => {
+    it('Should allow owner to update phases if launch has not started', async () => {
+      await expect(
+        flatLaunchpeg
+          .connect(bob)
+          .initializePhases(
+            config.preMintStartTime,
+            config.allowlistStartTime,
+            config.publicSaleStartTime,
+            config.publicSaleEndTime,
+            config.flatAllowlistSalePrice,
+            config.flatPublicSalePrice
+          )
+      ).to.be.revertedWith('PendingOwnableUpgradeable__NotOwner()')
 
-      config.allowlistStartTime = config.allowlistStartTime.add(120)
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)
+      expect(await flatLaunchpeg.preMintStartTime()).to.be.eq(config.preMintStartTime)
       expect(await flatLaunchpeg.allowlistStartTime()).to.be.eq(config.allowlistStartTime)
+      expect(await flatLaunchpeg.publicSaleStartTime()).to.be.eq(config.publicSaleStartTime)
+      expect(await flatLaunchpeg.publicSaleEndTime()).to.be.eq(config.publicSaleEndTime)
+      expect(await flatLaunchpeg.allowlistPrice()).to.be.eq(config.flatAllowlistSalePrice)
+      expect(await flatLaunchpeg.salePrice()).to.be.eq(config.flatPublicSalePrice)
+
+      config.allowlistStartTime = config.allowlistStartTime.add(duration.minutes(30))
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
+      expect(await flatLaunchpeg.allowlistStartTime()).to.be.eq(config.allowlistStartTime)
+
+      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)).to.be.revertedWith(
+        'Launchpeg__WrongPhase()'
+      )
     })
 
-    it('Sale dates should be correct', async () => {
+    it('Should revert if pre-mint start is before block timestamp', async () => {
       config.preMintStartTime = BigNumber.from(0)
-      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)).to.be.revertedWith(
+      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)).to.be.revertedWith(
         'Launchpeg__InvalidStartTime()'
       )
     })
 
-    it('Allowlist must happen after pre-mint', async () => {
+    it('Should revert if allowlist is before pre-mint', async () => {
       config.allowlistStartTime = config.preMintStartTime.sub(duration.minutes(20))
-
-      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)).to.be.revertedWith(
+      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)).to.be.revertedWith(
         'Launchpeg__AllowlistBeforePreMint()'
       )
     })
 
-    it('Public sale must happen after allowlist', async () => {
+    it('Should revert if public sale start is before allowlist start', async () => {
       config.publicSaleStartTime = config.allowlistStartTime.sub(duration.minutes(20))
-
-      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)).to.be.revertedWith(
+      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)).to.be.revertedWith(
         'Launchpeg__PublicSaleBeforeAllowlist()'
       )
     })
 
-    it('Public sale end time must be after public sale start time', async () => {
+    it('Should revert if public sale end time is before public sale start time', async () => {
       config.publicSaleEndTime = config.publicSaleStartTime.sub(duration.minutes(20))
-
-      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)).to.be.revertedWith(
+      await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)).to.be.revertedWith(
         'Launchpeg__PublicSaleEndBeforePublicSaleStart()'
       )
     })
 
-    it('Allowlist price should be lower than Public sale', async () => {
-      config.flatAllowlistSalePrice = config.flatAllowlistSalePrice.mul(10)
+    it('Should revert if allowlist price is higher than public sale price', async () => {
+      config.flatAllowlistSalePrice = config.flatPublicSalePrice.add(1)
       await expect(initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)).to.be.revertedWith(
         'Launchpeg__InvalidAllowlistPrice()'
       )
     })
+  })
 
-    it('Should not allow 0 batch reveal size', async () => {
-      config.batchRevealSize = 0
-      await expect(deployFlatLaunchpeg()).to.be.revertedWith('Launchpeg__InvalidBatchRevealSize()')
+  describe('Configure FlatLaunchpeg times', () => {
+    beforeEach(async () => {
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)
     })
 
-    it('Should not allow invalid reveal batch size', async () => {
-      config.batchRevealSize = config.batchRevealSize + 1
-      await expect(deployFlatLaunchpeg()).to.be.revertedWith('Launchpeg__InvalidBatchRevealSize()')
+    it('Should allow owner to set pre-mint start time', async () => {
+      const newPreMintStartTime = config.preMintStartTime.sub(duration.minutes(30))
+      await expect(flatLaunchpeg.connect(projectOwner).setPreMintStartTime(newPreMintStartTime)).to.be.revertedWith(
+        'PendingOwnableUpgradeable__NotOwner()'
+      )
+
+      await flatLaunchpeg.setPreMintStartTime(newPreMintStartTime)
+      expect(await flatLaunchpeg.preMintStartTime()).to.eq(newPreMintStartTime)
     })
 
-    it('Should not allow invalid reveal start time', async () => {
-      config.batchRevealStart = config.batchRevealStart.add(8_640_000)
-      await expect(deployFlatLaunchpeg()).to.be.revertedWith('Launchpeg__InvalidRevealDates()')
+    it('Should revert if pre-mint is before block timestamp or after allowlist', async () => {
+      const blockTimestamp = await latest()
+      let invalidPreMintStartTime = blockTimestamp.sub(duration.minutes(30))
+      await expect(flatLaunchpeg.setPreMintStartTime(invalidPreMintStartTime)).to.be.revertedWith(
+        'Launchpeg__InvalidStartTime()'
+      )
+
+      invalidPreMintStartTime = config.allowlistStartTime.add(duration.minutes(30))
+      await expect(flatLaunchpeg.setPreMintStartTime(invalidPreMintStartTime)).to.be.revertedWith(
+        'Launchpeg__AllowlistBeforePreMint()'
+      )
     })
 
-    it('Should not allow invalid reveal interval', async () => {
-      config.batchRevealInterval = config.batchRevealInterval.add(864_000)
-      await expect(deployFlatLaunchpeg()).to.be.revertedWith('Launchpeg__InvalidRevealDates()')
-    })
-
-    it('Reverts when setting pre-mint start time before phases are initialized', async () => {
+    it('Should revert when setting pre-mint start time before phases are initialized', async () => {
+      await deployFlatLaunchpeg()
       const newPreMintStartTime = config.preMintStartTime.sub(duration.minutes(30))
       await expect(flatLaunchpeg.setPreMintStartTime(newPreMintStartTime)).to.be.revertedWith(
         'Launchpeg__NotInitialized()'
       )
-    })
-
-    it('Reverts when setting allowlist start time before phases are initialized', async () => {
-      const newAllowlistStartTime = config.allowlistStartTime.sub(duration.minutes(30))
-      await expect(flatLaunchpeg.setAllowlistStartTime(newAllowlistStartTime)).to.be.revertedWith(
-        'Launchpeg__NotInitialized()'
-      )
-    })
-
-    it('Reverts when setting public sale start time before phases are initialized', async () => {
-      const newPublicSaleStartTime = config.publicSaleStartTime.sub(duration.minutes(30))
-      await expect(flatLaunchpeg.setPublicSaleStartTime(newPublicSaleStartTime)).to.be.revertedWith(
-        'Launchpeg__NotInitialized()'
-      )
-    })
-
-    it('Reverts when setting public sale end time before phases are initialized', async () => {
-      const newPublicSaleEndTime = config.publicSaleEndTime.sub(duration.minutes(30))
-      await expect(flatLaunchpeg.setPublicSaleEndTime(newPublicSaleEndTime)).to.be.revertedWith(
-        'Launchpeg__NotInitialized()'
-      )
-    })
-  })
-
-  describe('Project owner mint', () => {
-    it('Mint', async () => {
-      await flatLaunchpeg.connect(projectOwner).devMint(config.amountForDevs)
-      expect(await flatLaunchpeg.balanceOf(projectOwner.address)).to.eq(config.amountForDevs)
-    })
-
-    it('Only dev can mint', async () => {
-      await expect(flatLaunchpeg.connect(alice).devMint(1)).to.be.revertedWith(
-        'SafeAccessControlEnumerableUpgradeable__SenderMissingRoleAndIsNotOwner'
-      )
-    })
-
-    it('Mint after project owner changes', async () => {
-      await flatLaunchpeg.connect(dev).grantRole(flatLaunchpeg.PROJECT_OWNER_ROLE(), alice.address)
-      await flatLaunchpeg.connect(alice).devMint(config.amountForDevs)
-      expect(await flatLaunchpeg.balanceOf(alice.address)).to.eq(config.amountForDevs)
     })
   })
 
@@ -206,343 +204,140 @@ describe('FlatLaunchpeg', () => {
     })
 
     it('Should allow whitelisted user to pre-mint', async () => {
+      const allowlistPrice = config.flatAllowlistSalePrice
       const quantity = 1
-      await flatLaunchpeg.connect(alice).preMint(quantity, { value: config.flatAllowlistSalePrice.mul(quantity) })
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity)
+      await flatLaunchpeg.connect(alice).preMint(quantity, { value: allowlistPrice.mul(quantity) })
       expect(await flatLaunchpeg.amountMintedDuringPreMint()).to.eq(quantity)
-
-      await expect(flatLaunchpeg.connect(bob).preMint(1, { value: config.flatAllowlistSalePrice })).to.be.revertedWith(
-        'Launchpeg__NotEligibleForAllowlistMint'
-      )
-    })
-
-    it('Should receive allowlist price per NFT', async () => {
-      const quantity = 2
-      await flatLaunchpeg.connect(alice).preMint(quantity, { value: config.flatAllowlistSalePrice.mul(quantity) })
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity)
-
-      await expect(flatLaunchpeg.connect(alice).preMint(1)).to.be.revertedWith('Launchpeg__NotEnoughAVAX(0)')
-    })
-
-    it('Should allow user to pre-mint up to allowlist allocation', async () => {
-      const allowlistQty = await flatLaunchpeg.allowlist(alice.address)
-      const quantity = 3
-      const remQuantity = allowlistQty - quantity
-      await flatLaunchpeg.connect(alice).preMint(quantity, { value: config.flatAllowlistSalePrice.mul(quantity) })
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity)
-      expect(await flatLaunchpeg.allowlist(alice.address)).to.eq(remQuantity)
-
-      await expect(
-        flatLaunchpeg
-          .connect(alice)
-          .preMint(remQuantity + 1, { value: config.flatAllowlistSalePrice.mul(remQuantity + 1) })
-      ).to.be.revertedWith('Launchpeg__NotEligibleForAllowlistMint()')
-
-      await flatLaunchpeg.connect(alice).preMint(remQuantity, { value: config.flatAllowlistSalePrice.mul(remQuantity) })
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(alice.address)).to.eq(quantity + remQuantity)
-    })
-
-    it('Should not allow 0 pre-mint amount', async () => {
-      await expect(flatLaunchpeg.connect(alice).preMint(0)).to.be.revertedWith('Launchpeg__InvalidQuantity()')
-    })
-
-    it('Should not transfer pre-minted NFT to user', async () => {
-      await flatLaunchpeg.connect(alice).preMint(1, { value: config.flatAllowlistSalePrice })
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(alice.address)).to.eq(1)
-      expect(await flatLaunchpeg.balanceOf(alice.address)).to.eq(0)
-    })
-
-    it('Should allow users to pre-mint up to allowlist amount', async () => {
-      config = { ...(await getDefaultLaunchpegConfig()) }
-      config.amountForAllowlist = 5
-      await deployFlatLaunchpeg()
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PreMint)
-      await flatLaunchpeg.connect(dev).seedAllowlist([alice.address, bob.address], [5, 4])
-
-      const aliceQty = 4
-      const bobQty = 1
-      await flatLaunchpeg.connect(alice).preMint(aliceQty, { value: config.flatAllowlistSalePrice.mul(aliceQty) })
-      await flatLaunchpeg.connect(bob).preMint(bobQty, { value: config.flatAllowlistSalePrice.mul(bobQty) })
-
-      await expect(
-        flatLaunchpeg.connect(bob).preMint(bobQty, { value: config.flatAllowlistSalePrice.mul(bobQty) })
-      ).to.be.revertedWith('Launchpeg__MaxSupplyReached()')
-
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(alice.address)).to.eq(aliceQty)
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(bob.address)).to.eq(bobQty)
-      expect(await flatLaunchpeg.amountMintedDuringPreMint()).to.eq(aliceQty + bobQty)
     })
 
     it('Should not allow batch mint during pre-mint phase', async () => {
-      await flatLaunchpeg.connect(alice).preMint(1, { value: config.flatAllowlistSalePrice })
+      const allowlistPrice = config.flatAllowlistSalePrice
+      await flatLaunchpeg.connect(alice).preMint(1, { value: allowlistPrice })
       await expect(flatLaunchpeg.connect(bob).batchMintPreMintedNFTs(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
+    })
+
+    it('Should revert if user tries to mint for another phase', async () => {
+      await expect(flatLaunchpeg.connect(alice).allowlistMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
+      await expect(flatLaunchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
     })
   })
 
   describe('Allowlist phase', () => {
-    it('One NFT is transfered when user is on allowlist', async () => {
+    it('Should allow whitelisted user to mint up to allowlist allocation', async () => {
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-
-      await flatLaunchpeg.connect(dev).seedAllowlist([bob.address], [1])
-      await flatLaunchpeg.connect(bob).allowlistMint(1, { value: config.flatAllowlistSalePrice })
-      expect(await flatLaunchpeg.balanceOf(bob.address)).to.eq(1)
-    })
-
-    it('Mint reverts when not started yet', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)
-
-      await expect(flatLaunchpeg.connect(bob).allowlistMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
-    })
-
-    it('Mint reverts when the allowlist sale is over', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
-
-      await expect(flatLaunchpeg.connect(bob).allowlistMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
-    })
-
-    it('Mint reverts when user tries to mint more NFTs than allowed', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      const price = config.flatAllowlistSalePrice
-
       await flatLaunchpeg.connect(dev).seedAllowlist([bob.address], [2])
-      await flatLaunchpeg.connect(bob).allowlistMint(1, { value: price.mul(2) }) // intentionally sending more AVAX to test refund
-      await flatLaunchpeg.connect(bob).allowlistMint(1, { value: price })
 
-      await expect(flatLaunchpeg.connect(bob).allowlistMint(1, { value: price })).to.be.revertedWith(
+      const allowlistPrice = config.flatAllowlistSalePrice
+      await flatLaunchpeg.connect(bob).allowlistMint(1, { value: allowlistPrice })
+      // send more AVAX to test refund
+      await flatLaunchpeg.connect(bob).allowlistMint(1, { value: allowlistPrice.mul(2) })
+      expect(await flatLaunchpeg.balanceOf(bob.address)).to.eq(2)
+
+      await expect(flatLaunchpeg.connect(bob).allowlistMint(1, { value: allowlistPrice })).to.be.revertedWith(
         'Launchpeg__NotEligibleForAllowlistMint()'
       )
-      expect(await flatLaunchpeg.balanceOf(bob.address)).to.eq(2)
+      await expect(flatLaunchpeg.connect(alice).allowlistMint(1, { value: allowlistPrice })).to.be.revertedWith(
+        'Launchpeg__NotEligibleForAllowlistMint()'
+      )
     })
 
-    it('Mint reverts when user tries to mint more NFTs than allowlist amount', async () => {
+    it('Should revert if user pre-mints and allowlist mints more than collection size', async () => {
+      config.collectionSize = 5
+      config.amountForDevs = 0
       config.amountForAllowlist = 5
+      config.batchRevealSize = 5
       await deployFlatLaunchpeg()
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-
-      const price = config.flatAllowlistSalePrice
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PreMint)
       await flatLaunchpeg.connect(dev).seedAllowlist([alice.address, bob.address], [5, 5])
-      await flatLaunchpeg.connect(bob).allowlistMint(5, { value: price.mul(5) })
-      await expect(flatLaunchpeg.connect(alice).allowlistMint(1, { value: price })).to.be.revertedWith(
+      const allowlistPrice = config.flatAllowlistSalePrice
+
+      // Alice pre-mints
+      await flatLaunchpeg.connect(alice).preMint(1, { value: allowlistPrice })
+
+      // Bob allowlist mints
+      const blockTimestamp = await latest()
+      await advanceTimeAndBlock(duration.seconds(config.allowlistStartTime.sub(blockTimestamp).toNumber()))
+      await flatLaunchpeg.connect(bob).allowlistMint(4, { value: allowlistPrice.mul(4) })
+
+      await expect(flatLaunchpeg.connect(alice).allowlistMint(1, { value: allowlistPrice })).to.be.revertedWith(
         'Launchpeg__MaxSupplyReached()'
       )
     })
 
-    it('Mint reverts when the caller is not on allowlist during mint phase', async () => {
+    it('Should revert if user did not send enough funds', async () => {
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(flatLaunchpeg.connect(bob).allowlistMint(1)).to.be.revertedWith(
-        'Launchpeg__NotEligibleForAllowlistMint()'
-      )
-    })
+      await flatLaunchpeg.connect(dev).seedAllowlist([bob.address], [2])
 
-    it("Mint reverts when the caller didn't send enough AVAX", async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await flatLaunchpeg.connect(dev).seedAllowlist([alice.address], [1])
-      await expect(flatLaunchpeg.connect(alice).allowlistMint(1)).to.be.revertedWith('Launchpeg__NotEnoughAVAX(0)')
-    })
-
-    it('Seed allowlist reverts when addresses does not match numSlots length', async () => {
-      await expect(flatLaunchpeg.connect(dev).seedAllowlist([alice.address, bob.address], [1])).to.be.revertedWith(
-        'Launchpeg__WrongAddressesAndNumSlotsLength()'
-      )
+      await expect(flatLaunchpeg.connect(bob).allowlistMint(1)).to.be.revertedWith('Launchpeg__NotEnoughAVAX(0)')
     })
 
     it('Should allow any user to batch mint', async () => {
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PreMint)
-      await flatLaunchpeg.connect(dev).seedAllowlist([alice.address, bob.address], [10, 5])
+      await flatLaunchpeg.connect(dev).seedAllowlist([alice.address], [5])
 
-      // Alice and Bob pre-mint
-      const alicePreMintQty = 10
-      const bobPreMintQty = 5
-      await flatLaunchpeg
-        .connect(alice)
-        .preMint(alicePreMintQty, { value: config.flatAllowlistSalePrice.mul(alicePreMintQty) })
-      await flatLaunchpeg
-        .connect(bob)
-        .preMint(bobPreMintQty, { value: config.flatAllowlistSalePrice.mul(bobPreMintQty) })
+      // Alice pre-mints
+      const allowlistPrice = config.flatAllowlistSalePrice
+      const preMintQty = 2
+      await flatLaunchpeg.connect(alice).preMint(preMintQty, { value: allowlistPrice.mul(preMintQty) })
+
+      // Bob batch mints in allowlist phase
       const blockTimestamp = await latest()
       await advanceTimeAndBlock(duration.seconds(config.allowlistStartTime.sub(blockTimestamp).toNumber()))
-      expect(await flatLaunchpeg.balanceOf(alice.address)).to.eq(0)
-      expect(await flatLaunchpeg.balanceOf(bob.address)).to.eq(0)
-
-      // Bob batch mints
-      await flatLaunchpeg.connect(bob).batchMintPreMintedNFTs(5)
-      expect(await flatLaunchpeg.balanceOf(alice.address)).to.eq(5)
-      expect(await flatLaunchpeg.balanceOf(bob.address)).to.eq(0)
-
-      // Alice batch mints more than available in queue
-      await flatLaunchpeg.connect(alice).batchMintPreMintedNFTs(20)
-      expect(await flatLaunchpeg.balanceOf(alice.address)).to.eq(10)
-      expect(await flatLaunchpeg.balanceOf(bob.address)).to.eq(5)
-      expect(await flatLaunchpeg.amountBatchMinted()).to.eq(15)
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(alice.address)).to.eq(0)
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(bob.address)).to.eq(0)
-
-      await expect(flatLaunchpeg.batchMintPreMintedNFTs(5)).to.be.revertedWith(
-        'Launchpeg__MaxSupplyForBatchMintReached()'
-      )
+      await flatLaunchpeg.connect(bob).batchMintPreMintedNFTs(preMintQty)
+      expect(await flatLaunchpeg.balanceOf(alice.address)).to.eq(preMintQty)
     })
 
-    it('Should revert when there are no NFTs to batch mint', async () => {
+    it('Should revert if user tries to mint for another phase', async () => {
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(flatLaunchpeg.batchMintPreMintedNFTs(0)).to.be.revertedWith('Launchpeg__InvalidQuantity()')
-      await expect(flatLaunchpeg.batchMintPreMintedNFTs(5)).to.be.revertedWith(
-        'Launchpeg__MaxSupplyForBatchMintReached()'
-      )
-    })
-
-    it('Owner can set pre-mint start time', async () => {
-      let invalidPreMintStartTime = BigNumber.from(0)
-      const newPreMintStartTime = config.preMintStartTime.add(duration.minutes(30))
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PreMint)
-      await expect(flatLaunchpeg.connect(projectOwner).setPreMintStartTime(newPreMintStartTime)).to.be.revertedWith(
-        'PendingOwnableUpgradeable__NotOwner()'
-      )
-      await expect(flatLaunchpeg.setPreMintStartTime(invalidPreMintStartTime)).to.be.revertedWith(
-        'Launchpeg__InvalidStartTime()'
-      )
-      invalidPreMintStartTime = config.allowlistStartTime.add(duration.minutes(30))
-      await expect(flatLaunchpeg.setPreMintStartTime(invalidPreMintStartTime)).to.be.revertedWith(
-        'Launchpeg__AllowlistBeforePreMint()'
-      )
-      await flatLaunchpeg.setPreMintStartTime(newPreMintStartTime)
-      expect(await flatLaunchpeg.preMintStartTime()).to.eq(newPreMintStartTime)
-    })
-
-    it('Owner can set allowlist start time', async () => {
-      let invalidAllowlistStartTime = BigNumber.from(0)
-      const newAllowlistStartTime = config.allowlistStartTime.add(duration.minutes(30))
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(flatLaunchpeg.connect(projectOwner).setAllowlistStartTime(newAllowlistStartTime)).to.be.revertedWith(
-        'PendingOwnableUpgradeable__NotOwner()'
-      )
-      await expect(flatLaunchpeg.setAllowlistStartTime(invalidAllowlistStartTime)).to.be.revertedWith(
-        'Launchpeg__AllowlistBeforePreMint()'
-      )
-      invalidAllowlistStartTime = config.publicSaleStartTime.add(duration.minutes(30))
-      await expect(flatLaunchpeg.setAllowlistStartTime(invalidAllowlistStartTime)).to.be.revertedWith(
-        'Launchpeg__PublicSaleBeforeAllowlist()'
-      )
-      await flatLaunchpeg.setAllowlistStartTime(newAllowlistStartTime)
-      expect(await flatLaunchpeg.allowlistStartTime()).to.eq(newAllowlistStartTime)
-    })
-
-    it('Owner can set public sale start time', async () => {
-      let invalidPublicSaleStartTime = config.allowlistStartTime.sub(duration.minutes(30))
-      const newPublicSaleStartTime = config.publicSaleStartTime.sub(duration.minutes(30))
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(
-        flatLaunchpeg.connect(projectOwner).setPublicSaleStartTime(newPublicSaleStartTime)
-      ).to.be.revertedWith('PendingOwnableUpgradeable__NotOwner()')
-      await expect(flatLaunchpeg.setPublicSaleStartTime(invalidPublicSaleStartTime)).to.be.revertedWith(
-        'Launchpeg__PublicSaleBeforeAllowlist()'
-      )
-      invalidPublicSaleStartTime = config.publicSaleEndTime.add(duration.minutes(30))
-      await expect(flatLaunchpeg.setPublicSaleStartTime(invalidPublicSaleStartTime)).to.be.revertedWith(
-        'Launchpeg__PublicSaleEndBeforePublicSaleStart()'
-      )
-      await flatLaunchpeg.setPublicSaleStartTime(newPublicSaleStartTime)
-      expect(await flatLaunchpeg.publicSaleStartTime()).to.eq(newPublicSaleStartTime)
-    })
-
-    it('Owner can set public sale end time', async () => {
-      const invalidPublicSaleEndTime = config.publicSaleStartTime.sub(duration.minutes(30))
-      const newPublicSaleEndTime = config.publicSaleEndTime.sub(duration.minutes(30))
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(flatLaunchpeg.connect(projectOwner).setPublicSaleEndTime(newPublicSaleEndTime)).to.be.revertedWith(
-        'PendingOwnableUpgradeable__NotOwner()'
-      )
-      await expect(flatLaunchpeg.setPublicSaleEndTime(invalidPublicSaleEndTime)).to.be.revertedWith(
-        'Launchpeg__PublicSaleEndBeforePublicSaleStart()'
-      )
-      await flatLaunchpeg.setPublicSaleEndTime(newPublicSaleEndTime)
-      expect(await flatLaunchpeg.publicSaleEndTime()).to.eq(newPublicSaleEndTime)
-    })
-
-    it('Should allow owner to set reveal batch size', async () => {
-      const invalidRevealBatchSize = 101
-      const newRevealBatchSize = 100
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(
-        batchReveal.connect(projectOwner).setRevealBatchSize(flatLaunchpeg.address, newRevealBatchSize)
-      ).to.be.revertedWith('Ownable: caller is not the owner')
-      await expect(batchReveal.setRevealBatchSize(flatLaunchpeg.address, invalidRevealBatchSize)).to.be.revertedWith(
-        'Launchpeg__InvalidBatchRevealSize()'
-      )
-      await batchReveal.setRevealBatchSize(flatLaunchpeg.address, newRevealBatchSize)
-      const batchRevealConfig = await batchReveal.launchpegToConfig(flatLaunchpeg.address)
-      expect(batchRevealConfig[2]).to.eq(newRevealBatchSize)
-    })
-
-    it('Should allow owner to set reveal start time', async () => {
-      const invalidRevealStartTime = config.batchRevealStart.add(duration.minutes(8_640_000))
-      const newRevealStartTime = config.batchRevealStart.add(duration.minutes(30))
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(
-        batchReveal.connect(projectOwner).setRevealStartTime(flatLaunchpeg.address, newRevealStartTime)
-      ).to.be.revertedWith('Ownable: caller is not the owner')
-      await expect(batchReveal.setRevealStartTime(flatLaunchpeg.address, invalidRevealStartTime)).to.be.revertedWith(
-        'Launchpeg__InvalidRevealDates()'
-      )
-      await batchReveal.setRevealStartTime(flatLaunchpeg.address, newRevealStartTime)
-      const batchRevealConfig = await batchReveal.launchpegToConfig(flatLaunchpeg.address)
-      expect(batchRevealConfig[3]).to.eq(newRevealStartTime)
-    })
-
-    it('Should allow owner to set reveal interval', async () => {
-      const invalidRevealInterval = 864_001
-      const newRevealInterval = config.batchRevealInterval.add(10)
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await expect(
-        batchReveal.connect(projectOwner).setRevealInterval(flatLaunchpeg.address, newRevealInterval)
-      ).to.be.revertedWith('Ownable: caller is not the owner')
-      await expect(batchReveal.setRevealInterval(flatLaunchpeg.address, invalidRevealInterval)).to.be.revertedWith(
-        'Launchpeg__InvalidRevealDates()'
-      )
-      await batchReveal.setRevealInterval(flatLaunchpeg.address, newRevealInterval)
-      const batchRevealConfig = await batchReveal.launchpegToConfig(flatLaunchpeg.address)
-      expect(batchRevealConfig[4]).to.eq(newRevealInterval)
+      await expect(flatLaunchpeg.connect(alice).preMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
+      await expect(flatLaunchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
     })
   })
 
   describe('Public sale phase', () => {
-    it('The correct amount of NFTs is transfered when the user mints', async () => {
+    it('Should allow user to mint up to max batch size', async () => {
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
 
-      const quantity = 2
+      const quantity = config.maxBatchSize
       const price = config.flatPublicSalePrice
       await flatLaunchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
-      expect(await flatLaunchpeg.balanceOf(bob.address)).to.eq(2)
+      expect(await flatLaunchpeg.balanceOf(bob.address)).to.eq(quantity)
+
+      await expect(flatLaunchpeg.connect(bob).publicSaleMint(1, { value: price })).to.be.revertedWith(
+        'Launchpeg__CanNotMintThisMany()'
+      )
     })
 
-    it('Mint reverts if sale not started', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.NotStarted)
+    it('Should revert if user pre-mints and public sale mints more than collection size', async () => {
+      config.collectionSize = 5
+      config.amountForDevs = 0
+      config.amountForAllowlist = 5
+      config.batchRevealSize = 5
+      await deployFlatLaunchpeg()
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PreMint)
+      await flatLaunchpeg.connect(dev).seedAllowlist([alice.address, bob.address], [5, 5])
+      const allowlistPrice = config.flatAllowlistSalePrice
+      const publicSalePrice = config.flatPublicSalePrice
 
-      await expect(flatLaunchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
+      // Alice pre-mints
+      await flatLaunchpeg.connect(alice).preMint(1, { value: allowlistPrice })
+
+      // Bob public sale mints
+      const blockTimestamp = await latest()
+      await advanceTimeAndBlock(duration.seconds(config.publicSaleStartTime.sub(blockTimestamp).toNumber()))
+      await flatLaunchpeg.connect(bob).publicSaleMint(4, { value: publicSalePrice.mul(4) })
+
+      await expect(flatLaunchpeg.connect(alice).publicSaleMint(1, { value: publicSalePrice })).to.be.revertedWith(
+        'Launchpeg__MaxSupplyReached()'
+      )
     })
 
-    it('Mint reverts during allowlist phase', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-
-      await expect(flatLaunchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
-    })
-
-    it('Mint reverts when public sale has ended', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Ended)
-
-      await expect(flatLaunchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
-    })
-
-    it('Mint reverts when buy size > max allowed', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
-      await expect(flatLaunchpeg.connect(alice).publicSaleMint(6)).to.be.revertedWith('Launchpeg__CanNotMintThisMany()')
-    })
-
-    it('Mint reverts when not enough AVAX sent', async () => {
+    it('Should revert if user did not send enough funds', async () => {
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
       await expect(flatLaunchpeg.connect(alice).publicSaleMint(2)).to.be.revertedWith('Launchpeg__NotEnoughAVAX(0)')
     })
 
-    it('Mint reverts when maxSupply is reached', async () => {
+    it('Should revert when max supply is reached', async () => {
       config.collectionSize = 10
       config.amountForDevs = 0
       config.amountForAllowlist = 0
@@ -555,29 +350,13 @@ describe('FlatLaunchpeg', () => {
       const price = config.flatPublicSalePrice
       await flatLaunchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
 
-      quantity = 6
-      await expect(flatLaunchpeg.connect(alice).publicSaleMint(quantity)).to.be.revertedWith(
-        'Launchpeg__MaxSupplyReached()'
-      )
+      // Alice mints more than max supply
+      await expect(flatLaunchpeg.connect(alice).publicSaleMint(6)).to.be.revertedWith('Launchpeg__MaxSupplyReached()')
 
-      quantity = 5
+      // Bob mints up to max supply - phase ends
       await flatLaunchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
 
-      quantity = 1
-      await expect(flatLaunchpeg.connect(alice).publicSaleMint(quantity)).to.be.revertedWith('Launchpeg__WrongPhase()')
-    })
-
-    it('Mint reverts when address minted maxBatchSize', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
-
-      let quantity = config.maxBatchSize
-      const price = config.flatPublicSalePrice
-      await flatLaunchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
-
-      quantity = 1
-      await expect(
-        flatLaunchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
-      ).to.be.revertedWith('Launchpeg__CanNotMintThisMany()')
+      await expect(flatLaunchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
     })
 
     it('Should allow any user to batch mint', async () => {
@@ -585,202 +364,51 @@ describe('FlatLaunchpeg', () => {
       await flatLaunchpeg.connect(dev).seedAllowlist([alice.address], [5])
 
       // Alice pre-mints
+      const allowlistPrice = config.flatAllowlistSalePrice
       const preMintQty = 2
-      await flatLaunchpeg.connect(alice).preMint(preMintQty, { value: config.flatAllowlistSalePrice.mul(preMintQty) })
+      await flatLaunchpeg.connect(alice).preMint(preMintQty, { value: allowlistPrice.mul(preMintQty) })
+
+      // Bob batch mints in public sale phase
       const blockTimestamp = await latest()
       await advanceTimeAndBlock(duration.seconds(config.publicSaleStartTime.sub(blockTimestamp).toNumber()))
-      expect(await flatLaunchpeg.balanceOf(alice.address)).to.eq(0)
-
-      // Bob batch mints
-      await flatLaunchpeg.connect(bob).batchMintPreMintedNFTs(1)
-      expect(await flatLaunchpeg.balanceOf(alice.address)).to.eq(1)
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(alice.address)).to.eq(1)
-      // Alice batch mints more than available in queue
-      await flatLaunchpeg.connect(alice).batchMintPreMintedNFTs(2)
-      expect(await flatLaunchpeg.balanceOf(alice.address)).to.eq(2)
-      expect(await flatLaunchpeg.amountBatchMinted()).to.eq(2)
-      expect(await flatLaunchpeg.userAddressToPreMintAmount(alice.address)).to.eq(0)
-
-      await expect(flatLaunchpeg.batchMintPreMintedNFTs(5)).to.be.revertedWith(
-        'Launchpeg__MaxSupplyForBatchMintReached()'
-      )
+      await flatLaunchpeg.connect(bob).batchMintPreMintedNFTs(preMintQty)
+      expect(await flatLaunchpeg.balanceOf(alice.address)).to.eq(preMintQty)
     })
 
-    it('Should not allow batch mint after public sale', async () => {
+    it('Should revert if user tries to mint for another phase', async () => {
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
+      await expect(flatLaunchpeg.connect(alice).preMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
+      await expect(flatLaunchpeg.connect(alice).allowlistMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
+    })
+
+    it('Should revert when public sale has ended', async () => {
       await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Ended)
-      await expect(flatLaunchpeg.batchMintPreMintedNFTs(5)).to.be.revertedWith('Launchpeg__WrongPhase()')
-    })
-
-    it('Owner can set public sale end time', async () => {
-      const newPublicSaleEndTime = config.publicSaleEndTime.sub(duration.minutes(30))
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
-      await flatLaunchpeg.setPublicSaleEndTime(newPublicSaleEndTime)
-      expect(await flatLaunchpeg.publicSaleEndTime()).to.eq(newPublicSaleEndTime)
+      await expect(flatLaunchpeg.connect(alice).publicSaleMint(1)).to.be.revertedWith('Launchpeg__WrongPhase()')
     })
   })
 
-  describe('Transfers', () => {
-    it('Owner of an NFT should be able to transfer it', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
+  describe('Pause FlatLaunchpeg methods', () => {
+    let PAUSER_ROLE: Bytes
+    let UNPAUSER_ROLE: Bytes
 
-      const quantity = 2
-      const price = config.flatPublicSalePrice
-      await flatLaunchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
-      expect(await flatLaunchpeg.ownerOf(1)).to.eq(bob.address)
-      await flatLaunchpeg.connect(bob).transferFrom(bob.address, alice.address, 1)
-      expect(await flatLaunchpeg.ownerOf(1)).to.eq(alice.address)
-    })
-
-    it('Owner of an NFT should be able to give allowance', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
-
-      const quantity = 2
-      const price = config.flatPublicSalePrice
-      await flatLaunchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
-
-      await flatLaunchpeg.connect(bob).approve(alice.address, 1)
-      await flatLaunchpeg.connect(alice).transferFrom(bob.address, alice.address, 1)
-      expect(await flatLaunchpeg.ownerOf(1)).to.eq(alice.address)
-    })
-
-    it('TransferFrom with no allowance should fail', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
-
-      const quantity = 2
-      const price = config.flatPublicSalePrice
-      await flatLaunchpeg.connect(bob).publicSaleMint(quantity, { value: price.mul(quantity) })
-      await expect(flatLaunchpeg.connect(alice).transferFrom(bob.address, alice.address, 1)).to.be.revertedWith(
-        'TransferCallerNotOwnerNorApproved()'
-      )
-      expect(await flatLaunchpeg.ownerOf(1)).to.eq(bob.address)
-    })
-  })
-
-  describe('Funds flow', () => {
-    it('Owner can withdraw money', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
-      // For some reason the contract has some balance initially, for this particular test only
-      const initialContractBalance = await ethers.provider.getBalance(flatLaunchpeg.address)
-
-      await flatLaunchpeg.connect(alice).publicSaleMint(5, { value: config.flatPublicSalePrice.mul(5) })
-      await flatLaunchpeg.connect(bob).publicSaleMint(4, { value: config.flatPublicSalePrice.mul(4) })
-
-      const initialDevBalance = await dev.getBalance()
-
-      await flatLaunchpeg.connect(dev).withdrawAVAX(dev.address)
-      expect(await dev.getBalance()).to.be.closeTo(
-        initialDevBalance.add(config.flatPublicSalePrice.mul(9).add(initialContractBalance)),
-        ethers.utils.parseEther('0.01')
-      )
-    })
-
-    it('Project owner can withdraw money', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
-      // For some reason the contract has some balance initially, for this particular test only
-      const initialContractBalance = await ethers.provider.getBalance(flatLaunchpeg.address)
-
-      await flatLaunchpeg.connect(alice).publicSaleMint(5, { value: config.flatPublicSalePrice.mul(5) })
-      await flatLaunchpeg.connect(bob).publicSaleMint(4, { value: config.flatPublicSalePrice.mul(4) })
-
-      const initialBalance = await projectOwner.getBalance()
-
-      await flatLaunchpeg.connect(projectOwner).withdrawAVAX(projectOwner.address)
-      expect(await projectOwner.getBalance()).to.be.closeTo(
-        initialBalance.add(config.flatPublicSalePrice.mul(9).add(initialContractBalance)),
-        ethers.utils.parseEther('0.01')
-      )
-    })
-
-    it("Can't withdraw before start time", async () => {
-      const blockTimestamp = await latest()
-      config.withdrawAVAXStartTime = blockTimestamp.add(duration.days(1))
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
-
-      await expect(flatLaunchpeg.connect(projectOwner).withdrawAVAX(projectOwner.address)).to.be.revertedWith(
-        'Launchpeg__WithdrawAVAXNotAvailable()'
-      )
-    })
-
-    it("Can't set start time before current block timestamp", async () => {
-      const blockTimestamp = await latest()
-      await expect(flatLaunchpeg.setWithdrawAVAXStartTime(blockTimestamp.sub(duration.minutes(1)))).to.be.revertedWith(
-        'Launchpeg__InvalidStartTime()'
-      )
-    })
-
-    it("Can't withdraw when start time not initialized", async () => {
-      await expect(flatLaunchpeg.connect(projectOwner).withdrawAVAX(projectOwner.address)).to.be.revertedWith(
-        'Launchpeg__WithdrawAVAXNotAvailable()'
-      )
-    })
-
-    it('Fee correctly sent to collector address', async () => {
-      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
-
-      const feePercent = 200
-      const feeCollector = bob
-      await flatLaunchpeg.initializeJoeFee(feePercent, feeCollector.address)
-
-      const total = config.flatPublicSalePrice.mul(5)
-      await flatLaunchpeg.connect(alice).publicSaleMint(5, { value: config.flatPublicSalePrice.mul(5) })
-
-      const fee = total.mul(feePercent).div(10000)
-      const initialDevBalance = await dev.getBalance()
-      const initialFeeCollectorBalance = await feeCollector.getBalance()
-      await flatLaunchpeg.connect(dev).withdrawAVAX(dev.address)
-
-      expect(await dev.getBalance()).to.be.closeTo(
-        initialDevBalance.add(total.sub(fee)),
-        ethers.utils.parseEther('0.01')
-      )
-      expect(await feeCollector.getBalance()).to.be.eq(initialFeeCollectorBalance.add(fee))
-    })
-  })
-
-  describe('SafePausable', () => {
     beforeEach(async () => {
       PAUSER_ROLE = await flatLaunchpeg.PAUSER_ROLE()
       UNPAUSER_ROLE = await flatLaunchpeg.UNPAUSER_ROLE()
     })
 
     it('Should allow owner or pauser to pause mint methods', async () => {
+      await initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.PublicSale)
       await flatLaunchpeg.grantRole(PAUSER_ROLE, alice.address)
       await flatLaunchpeg.connect(alice).pause()
-      await expect(flatLaunchpeg.connect(dev).devMint(1)).to.be.revertedWith('Pausable: paused')
-      await expect(flatLaunchpeg.connect(bob).allowlistMint(1)).to.be.revertedWith('Pausable: paused')
-      await expect(flatLaunchpeg.publicSaleMint(1)).to.be.revertedWith('Pausable: paused')
+      await expect(flatLaunchpeg.devMint(1)).to.be.revertedWith('Pausable: paused')
+      await expect(flatLaunchpeg.preMint(1)).to.be.revertedWith('Pausable: paused')
+      await expect(flatLaunchpeg.batchMintPreMintedNFTs(1)).to.be.revertedWith('Pausable: paused')
+      await expect(flatLaunchpeg.allowlistMint(1)).to.be.revertedWith('Pausable: paused')
+      await expect(flatLaunchpeg.connect(bob).publicSaleMint(1)).to.be.revertedWith('Pausable: paused')
 
       await flatLaunchpeg.grantRole(UNPAUSER_ROLE, alice.address)
       await flatLaunchpeg.connect(alice).unpause()
-      await flatLaunchpeg.connect(dev).devMint(1)
-    })
-
-    it('Should allow owner or pauser to pause funds withdrawal', async () => {
-      initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Allowlist)
-      await flatLaunchpeg.pause()
-      await expect(flatLaunchpeg.connect(projectOwner).withdrawAVAX(alice.address)).to.be.revertedWith(
-        'Pausable: paused'
-      )
-
-      await flatLaunchpeg.unpause()
-      await flatLaunchpeg.connect(projectOwner).withdrawAVAX(alice.address)
-    })
-
-    it('Should allow owner or pauser to pause batch reveal', async () => {
-      config.collectionSize = 50
-      config.amountForDevs = 10
-      config.amountForAuction = 0
-      config.amountForAllowlist = 0
-      config.batchRevealSize = 10
-      await deployFlatLaunchpeg()
-      initializePhasesFlatLaunchpeg(flatLaunchpeg, config, Phase.Reveal)
-
-      await flatLaunchpeg.devMint(10)
-      await flatLaunchpeg.pause()
-      await expect(flatLaunchpeg.connect(alice).revealNextBatch()).to.be.revertedWith('Pausable: paused')
-
-      await flatLaunchpeg.unpause()
-      await flatLaunchpeg.connect(alice).revealNextBatch()
+      await flatLaunchpeg.connect(bob).publicSaleMint(1, { value: config.flatPublicSalePrice })
     })
   })
 


### PR DESCRIPTION
This PR:
- Re-factors common Launchpeg tests into a `BaseLaunchpeg.test.ts` file
- Updates `BatchReveal` tests

Current coverage:
File                   |  % Stmts | % Branch |  % Funcs |  % Lines |
-----------------------|----------|----------|----------|----------|
  BaseLaunchpeg.sol    |    99.19 |    94.87 |       96 |    96.84 |
  BatchReveal.sol      |      100 |      100 |      100 |      100 |
  FlatLaunchpeg.sol    |    98.04 |      100 |    91.67 |    98.41 |
  Launchpeg.sol        |    98.89 |      100 |    94.12 |    99.09 |
  LaunchpegErrors.sol  |      100 |      100 |      100 |      100 |
  LaunchpegFactory.sol |      100 |      100 |      100 |      100 |
  **All files**        |    99.35 |    98.41 |    96.63 |    98.75 |